### PR TITLE
initialize cell_to_data in setup_system()

### DIFF
--- a/include/dealiiqc/qc.h
+++ b/include/dealiiqc/qc.h
@@ -175,6 +175,16 @@ namespace dealiiqc
      */
     struct AssemblyData
     {
+      AssemblyData()
+      {
+      };
+
+      ~AssemblyData()
+      {
+        Assert(fe_values.use_count() < 2,
+               ExcMessage("use count: " + std::to_string(fe_values.use_count())));
+      }
+
       /**
        * FEValues object to evaluate fields and shape function values at
        * quadrature points.

--- a/source/qc/core.cc
+++ b/source/qc/core.cc
@@ -73,6 +73,10 @@ namespace dealiiqc
 
     displacement = 0.;
     locally_relevant_displacement = displacement;
+
+    cells_to_data.clear();
+    for (auto cell = dof_handler.begin_active(); cell != dof_handler.end(); cell++)
+      cells_to_data.insert(std::make_pair(cell,AssemblyData()));
   }
 
   template <int dim>
@@ -110,6 +114,9 @@ namespace dealiiqc
         Assert (points.size() > 0,
                 ExcMessage("Cell does not have any atoms at which fields and "
                            "shape functions are to be evaluated."));
+
+        Assert (data.fe_values.use_count() ==0,
+                ExcInternalError());
 
         // Now we are ready to initialize FEValues object.
         data.fe_values = std::make_shared<FEValues<dim>>(mapping, fe,
@@ -296,7 +303,10 @@ namespace dealiiqc
         a.parent_cell = my_pair.first;
 
         // add this atom to cell
-        cells_to_data[a.parent_cell].cell_atoms.push_back(i);
+        auto data = cells_to_data.find(a.parent_cell);
+        Assert (data != cells_to_data.end(),
+                ExcInternalError());
+        data->second.cell_atoms.push_back(i);
       }
   }
 


### PR DESCRIPTION
part of https://github.com/davydden/deal.ii-qc/pull/11 without unique pointers for now.

Actually it's fine when `AssemblyData` gets deleted with objects which have `use_counter <=1`, this is now checked in `Assert` and is respected. I will further debug the issue after I can reproduce it on Ubuntu
