### PR TITLE
fix clang warning

### DIFF
--- a/source/potentials/pair_lj_cut.cc
+++ b/source/potentials/pair_lj_cut.cc
@@ -32,10 +32,7 @@ namespace dealiiqc
       Assert (parameters[1] > 0.,
               ExcMessage("Invalid r_m value specified for LJ pair potential"));
 
-      std::array<double, 2> params { parameters[0],
-                                     dealii::Utilities::fixed_power<6>(parameters[1])
-                                   };
-
+      const std::array<double, 2> params = {{parameters[0],dealii::Utilities::fixed_power<6>(parameters[1])}};
       lj_parameters.insert( std::make_pair( get_pair(i_atom_type, j_atom_type),
                                             params) );
 


### PR DESCRIPTION
it's clang's bug http://stackoverflow.com/questions/13905200/is-it-wise-to-ignore-gcc-clangs-wmissing-braces-warning but i still prefer to make compiler happy.