### PR TITLE
remove calculate_cell_radius() function

### DIFF
--- a/include/dealiiqc/utilities.h
+++ b/include/dealiiqc/utilities.h
@@ -64,7 +64,7 @@ namespace dealiiqc
                    ExcMessage( "The given cell iterator is not in a valid iterator state"));
 
       for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
-        if (  (cell->vertex(v)- p).norm_square()
+        if (  p.distance_square(cell->vertex(v))
               < dealii::Utilities::fixed_power<2>( distance ) )
           return true;
       return false;
@@ -90,22 +90,6 @@ namespace dealiiqc
 
       return false;
     }
-
-    /**
-     * Return radius of a given @p cell.
-     * The radius of the cell is defined as the distance from
-     * center of the cell to the farthest vertex.
-     */
-    template <int dim, typename Cell>
-    inline
-    double calculate_cell_radius(const Cell &cell)
-    {
-      double res = 0.;
-      for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
-        res = std::max(res, ( (cell->vertex(v)-cell->center()).norm_square() ));
-      return std::sqrt(res);
-    }
-
 
   } // Utilities
 


### PR DESCRIPTION
- Replace `calculate_cell_radius()` with `enclosing_ball()`.
- But keeping `is_outside_bounding_box()` as it is already tested and could be used in the future.