### PR TITLE
move split_list_of_string_lists() to Utilities

### DIFF
--- a/include/dealiiqc/utilities.h
+++ b/include/dealiiqc/utilities.h
@@ -47,6 +47,8 @@ namespace dealiiqc
   {
     using namespace dealii;
 
+
+
     /**
      * Function to check if a Point @p p is a within a certain
      * @p distance from the vertices of a given parent cell.
@@ -70,6 +72,8 @@ namespace dealiiqc
       return false;
     }
 
+
+
     /**
      * Utility function that returns true if a point @p p is outside a bounding box.
      * The box is specified by two points @p minp and @p maxp (the order of
@@ -90,6 +94,52 @@ namespace dealiiqc
 
       return false;
     }
+
+
+
+    /**
+     * Given a string that contains a list of @p minor_delimiter separated
+     * text separated by a @p major_delimiter, split it into its components,
+     * remove leading and trailing spaces.
+     *
+     * The input string can end without specifying any delimiters (possibly
+     * followed by an arbitrary amount of whitespace). For example,
+     * @code
+     *   Utilities::split_list_of_string_lists("abc, def; ghi; j, k, l; ", ';', ',');
+     * @endcode
+     * yields the same 3-element list of sub-lists output
+     * <code>{ {"abc", "def"},{"ghi"}, {"j", "k", "l"}}</code>
+     * as you would get if the input had been
+     * @code
+     *   Utilities::split_list_of_string_lists("abc, def; ghi; j, k, l", ';', ',');
+     * @endcode
+     * or
+     * @code
+     *   Utilities::split_list_of_string_lists("abc, def; ghi; j, k, l;", ';', ',');
+     * @endcode
+     */
+    inline
+    std::vector<std::vector<std::string> >
+    split_list_of_string_lists (const std::string &s,
+                                const char major_delimiter = ';',
+                                const char minor_delimiter = ',')
+    {
+      AssertThrow (major_delimiter!=minor_delimiter,
+                   ExcMessage("Invalid major and minor delimiters provided!"));
+
+      std::vector<std::vector<std::string>> res;
+
+      const std::vector<std::string> coeffs_per_type =
+        dealii::Utilities::split_string_list (s,
+                                              major_delimiter);
+      res.resize(coeffs_per_type.size());
+      for (unsigned int i = 0; i < coeffs_per_type.size(); ++i)
+        res[i] = dealii::Utilities::split_string_list (coeffs_per_type[i],
+                                                       minor_delimiter);
+      return res;
+    }
+
+
 
   } // Utilities
 

--- a/source/io/configure_qc.cc
+++ b/source/io/configure_qc.cc
@@ -152,51 +152,7 @@ namespace dealiiqc
 
   }
 
-  namespace
-  {
-    // TODO: Move this to Utilities.
-    /**
-     * Given a string that contains a list of @p minor_delimiter separated
-     * text separated by a @p major_delimiter, split it into its components,
-     * remove leading and trailing spaces.
-     *
-     * The input string can end without specifying any delimiters (possibly
-     * followed by an arbitrary amount of whitespace). For example,
-     * @code
-     *   Utilities::split_list_of_string_lists("abc, def; ghi; j, k, l; ", ';', ',');
-     * @endcode
-     * yields the same 3-element list of sub-lists output
-     * <code>{ {"abc", "def"},{"ghi"}, {"j", "k", "l"}}</code>
-     * as you would get if the input had been
-     * @code
-     *   Utilities::split_list_of_string_lists("abc, def; ghi; j, k, l", ';', ',');
-     * @endcode
-     * or
-     * @code
-     *   Utilities::split_list_of_string_lists("abc, def; ghi; j, k, l;", ';', ',');
-     * @endcode
-     */
-    inline
-    std::vector<std::vector<std::string>>
-                                       split_list_of_string_lists (const std::string &s,
-                                           const char major_delimiter = ';',
-                                           const char minor_delimiter = ',')
-    {
-      AssertThrow (major_delimiter!=minor_delimiter,
-                   ExcMessage("Invalid major and minor delimiters provided!"));
 
-      std::vector<std::vector<std::string>> res;
-
-      const std::vector<std::string> coeffs_per_type =
-        dealii::Utilities::split_string_list (s,
-                                              major_delimiter);
-      res.resize(coeffs_per_type.size());
-      for (unsigned int i = 0; i < coeffs_per_type.size(); ++i)
-        res[i] = dealii::Utilities::split_string_list (coeffs_per_type[i],
-                                                       minor_delimiter);
-      return res;
-    }
-  }
 
   void ConfigureQC::parse_parameters( ParameterHandler &prm )
   {
@@ -222,8 +178,8 @@ namespace dealiiqc
           global_coeffs.push_back(dealii::Utilities::string_to_double(c));
       }
 
-      const std::vector<std::vector<std::string>> list_of_coeffs_per_type =
-                                                 /*Utilities::*/split_list_of_string_lists(prm.get("Pair specific coefficients"),';',',');
+      const std::vector<std::vector<std::string> > list_of_coeffs_per_type =
+        Utilities::split_list_of_string_lists(prm.get("Pair specific coefficients"),';',',');
 
       if (pair_potential_type == "Coulomb Wolf")
         {


### PR DESCRIPTION
Files touched in this PR: `utitlities.h` and `configure_qc.cc`. [Just for my information.]