### PR TITLE
remove neighbor_lists from AtomData

### DIFF
--- a/include/dealiiqc/atom/atom_data.h
+++ b/include/dealiiqc/atom/atom_data.h
@@ -83,14 +83,6 @@ namespace dealiiqc
     std::multimap<types::CellIteratorType<dim>, Atom<dim>> energy_atoms;
 
     /**
-     * Neighbor lists using cell approach.
-     * For each cell loop over all nearby relevant cells only once
-     * and loop over all interacting atoms between the two cells.
-     */
-    std::multimap< std::pair<types::ConstCellIteratorType<dim>, types::ConstCellIteratorType<dim>>, std::pair<types::CellAtomConstIteratorType<dim>, types::CellAtomConstIteratorType<dim> > >
-        neighbor_lists;
-
-    /**
      * Number of locally relevant non-energy atoms per cell.
      * This is exactly the number of non-energy atoms for whom a
      * locally relevant cell is found while updating @see energy_atoms.

--- a/tests/atom/atom_handler_neigh_list_01.cc
+++ b/tests/atom/atom_handler_neigh_list_01.cc
@@ -36,9 +36,9 @@ public:
     GridGenerator::hyper_cube( triangulation, 0., 16., true );
     triangulation.refine_global (3);
     AtomHandler<dim>::parse_atoms_and_assign_to_cells( dof_handler, atom_data);
-    atom_data.neighbor_lists =
+    auto neighbor_lists =
       AtomHandler<dim>::get_neighbor_lists( atom_data.energy_atoms);
-    for ( auto entry : atom_data.neighbor_lists)
+    for ( auto entry : neighbor_lists)
       std::cout << "Atom I: "  << entry.second.first->second.global_index << " "
                 << "Atom J: "  << entry.second.second->second.global_index << std::endl;
     std::cout << std::endl;


### PR DESCRIPTION
There is a duplication of `neighbor_lists`; it was both in `QC` class and also in `AtomData`. So through this PR,
- Remove `neighbor_lists` from `AtomData`
- Update a test that was using it.