### PR TITLE
rename energy_and_scalar_force -> energy_and_gradient

### DIFF
--- a/include/dealiiqc/potentials/pair_coul_wolf.h
+++ b/include/dealiiqc/potentials/pair_coul_wolf.h
@@ -47,7 +47,7 @@ namespace dealiiqc
        * interact with each other, consequently do not contribute to either
        * energy or its derivative.
        */
-      PairCoulWolfManager( const double &alpha,
+      PairCoulWolfManager (const double &alpha,
                            const double &cutoff_radius);
 
       /**
@@ -56,19 +56,19 @@ namespace dealiiqc
        * this class and is present here only for consistency with the other
        * potentials.
        */
-      void declare_interactions ( const types::atom_type i_atom_type,
-                                  const types::atom_type j_atom_type,
-                                  InteractionTypes interaction,
-                                  const std::vector<double> &parameters=std::vector<double>());
+      void declare_interactions (const types::atom_type i_atom_type,
+                                 const types::atom_type j_atom_type,
+                                 InteractionTypes interaction,
+                                 const std::vector<double> &parameters=std::vector<double>());
 
       /**
-       * Returns a pair of computed values of energy and scalar force between
-       * two atoms of type @p i_atom_type and atom_type @p j_atom_type
+       * Returns a pair of computed values of energy and its gradient between
+       * two atoms of type @p i_atom_type and type @p j_atom_type
        * that are a distance of square root of @p squared_distance apart.
        * The first value in the returned pair is energy whereas the second
-       * is its (scalar) derivative, i.e. scalar force.
+       * is its (scalar) derivative, i.e. negative scalar force.
        * The template parameter indicates whether to skip the additional
-       * computation of scalar force; this is in the case when only the
+       * computation of gradient; this is in the case when only the
        * value of the energy is intended to be queried.
        *
        * @note A typical energy minimization process might need the value of
@@ -76,12 +76,12 @@ namespace dealiiqc
        * this function can be called by passing @p false as template
        * parameter to query only the computation of the energy.
        */
-      template<bool ComputeScalarForce=true>
+      template<bool ComputeGradient=true>
       inline
       std::pair<double, double>
-      energy_and_scalar_force ( const types::atom_type i_atom_type,
-                                const types::atom_type j_atom_type,
-                                const double &squared_distance) const;
+      energy_and_gradient (const types::atom_type i_atom_type,
+                           const types::atom_type j_atom_type,
+                           const double &squared_distance) const;
 
     private:
 

--- a/include/dealiiqc/potentials/pair_lj_cut.h
+++ b/include/dealiiqc/potentials/pair_lj_cut.h
@@ -49,7 +49,7 @@ namespace dealiiqc
        * are farther than @p cutoff_radius do not interact with each other,
        * consequently do not contribute to either energy or it's derivative.
        */
-      PairLJCutManager( const double &cutoff_radius);
+      PairLJCutManager (const double &cutoff_radius);
 
       /**
        * Declare the type of interaction between the atom types @p i_atom_type
@@ -60,33 +60,21 @@ namespace dealiiqc
        * being \f$\epsilon\f$ and second being \f$r_m\f$ as defined in
        * PairLJCutManager.
        */
-      void declare_interactions ( const types::atom_type i_atom_type,
-                                  const types::atom_type j_atom_type,
-                                  const InteractionTypes interaction,
-                                  const std::vector<double> &parameters);
+      void declare_interactions (const types::atom_type i_atom_type,
+                                 const types::atom_type j_atom_type,
+                                 const InteractionTypes interaction,
+                                 const std::vector<double> &parameters);
 
 
       /**
-       * Returns a pair of computed value of energy and scalar force between
-       * two atoms with atom type @p i_atom_type and atom_type @p j_atom_type
-       * that are a distance of square root of @p squared_distance apart.
-       * The first value in the returned pair is energy whereas the second
-       * is its (scalar) derivative, i.e. scalar force.
-       * The template parameter indicates whether to skip the additional
-       * computation of scalar force; this is in the case when only the
-       * value of the energy is intended to be queried.
-       *
-       * @note A typical energy minimization process might need the value of
-       * energy much more often than the value of force. Therefore,
-       * this function can be called by passing @p false as template
-       * parameter to query only the computation of the energy.
+       * @copydoc PairCoulWolfManager::energy_and_gradient()
        */
-      template<bool ComputeScalarForce=true>
+      template<bool ComputeGradient=true>
       inline
       std::pair<double, double>
-      energy_and_scalar_force ( const types::atom_type i_atom_type,
-                                const types::atom_type j_atom_type,
-                                const double &squared_distance) const;
+      energy_and_gradient (const types::atom_type i_atom_type,
+                           const types::atom_type j_atom_type,
+                           const double &squared_distance) const;
 
     private:
 

--- a/source/potentials/pair_coul_wolf.cc
+++ b/source/potentials/pair_coul_wolf.cc
@@ -11,8 +11,8 @@ namespace dealiiqc
   {
 
 
-    PairCoulWolfManager::PairCoulWolfManager ( const double &alpha,
-                                               const double &cutoff_radius)
+    PairCoulWolfManager::PairCoulWolfManager (const double &alpha,
+                                              const double &cutoff_radius)
       :
       alpha(alpha),
       cutoff_radius(cutoff_radius),
@@ -23,10 +23,10 @@ namespace dealiiqc
 
 
     void
-    PairCoulWolfManager::declare_interactions ( const types::atom_type i_atom_type,
-                                                const types::atom_type j_atom_type,
-                                                InteractionTypes interaction,
-                                                const std::vector<double> &parameters)
+    PairCoulWolfManager::declare_interactions (const types::atom_type i_atom_type,
+                                               const types::atom_type j_atom_type,
+                                               InteractionTypes interaction,
+                                               const std::vector<double> &parameters)
     {
       Assert( interaction==InteractionTypes::Coul_Wolf,
               ExcMessage("Invalid InteractionTypes specified"));
@@ -39,14 +39,14 @@ namespace dealiiqc
               ExcMessage("This class does not accept any parameters."));
     }
 
-    template<bool ComputeScalarForce>
+    template<bool ComputeGradient>
     std::pair<double, double>
-    PairCoulWolfManager::energy_and_scalar_force ( const types::atom_type i_atom_type,
-                                                   const types::atom_type j_atom_type,
-                                                   const double &squared_distance) const
+    PairCoulWolfManager::energy_and_gradient (const types::atom_type i_atom_type,
+                                              const types::atom_type j_atom_type,
+                                              const double &squared_distance) const
     {
       if ( squared_distance > cutoff_radius*cutoff_radius )
-        return ComputeScalarForce
+        return ComputeGradient
                ?
                std::make_pair(0.,0.)
                :
@@ -72,7 +72,7 @@ namespace dealiiqc
 
       const double energy = qiqj * ( erfc_a_distance - energy_shift ) * qqrd2e;
 
-      const double force = ComputeScalarForce
+      const double force = ComputeGradient
                            ?
                            qqrd2e * qiqj *
                            ( distance_inverse *
@@ -95,15 +95,15 @@ namespace dealiiqc
 
     template
     std::pair<double, double>
-    PairCoulWolfManager::energy_and_scalar_force <true> ( const types::atom_type i_atom_type,
-                                                          const types::atom_type j_atom_type,
-                                                          const double &squared_distance) const;
+    PairCoulWolfManager::energy_and_gradient <true> (const types::atom_type i_atom_type,
+                                                     const types::atom_type j_atom_type,
+                                                     const double &squared_distance) const;
 
     template
     std::pair<double, double>
-    PairCoulWolfManager::energy_and_scalar_force <false> ( const types::atom_type i_atom_type,
-                                                           const types::atom_type j_atom_type,
-                                                           const double &squared_distance) const;
+    PairCoulWolfManager::energy_and_gradient <false> (const types::atom_type i_atom_type,
+                                                      const types::atom_type j_atom_type,
+                                                      const double &squared_distance) const;
   }
 
 }

--- a/source/potentials/pair_lj_cut.cc
+++ b/source/potentials/pair_lj_cut.cc
@@ -12,16 +12,16 @@ namespace dealiiqc
   namespace Potential
   {
 
-    PairLJCutManager::PairLJCutManager( const double &cutoff_radius)
+    PairLJCutManager::PairLJCutManager (const double &cutoff_radius)
       :
       cutoff_radius_squared(cutoff_radius *cutoff_radius)
     {}
 
     void
-    PairLJCutManager::declare_interactions ( const types::atom_type i_atom_type,
-                                             const types::atom_type j_atom_type,
-                                             const InteractionTypes interaction,
-                                             const std::vector<double> &parameters)
+    PairLJCutManager::declare_interactions (const types::atom_type i_atom_type,
+                                            const types::atom_type j_atom_type,
+                                            const InteractionTypes interaction,
+                                            const std::vector<double> &parameters)
     {
       Assert( interaction==InteractionTypes::LJ,
               ExcMessage("Invalid InteractionTypes specified"));
@@ -38,15 +38,15 @@ namespace dealiiqc
 
     }
 
-    template<bool ComputeScalarForce>
+    template<bool ComputeGradient>
     std::pair<double, double>
-    PairLJCutManager::energy_and_scalar_force ( const types::atom_type i_atom_type,
-                                                const types::atom_type j_atom_type,
-                                                const double &squared_distance) const
+    PairLJCutManager::energy_and_gradient (const types::atom_type i_atom_type,
+                                           const types::atom_type j_atom_type,
+                                           const double &squared_distance) const
     {
 
       if ( squared_distance > cutoff_radius_squared)
-        return ComputeScalarForce
+        return ComputeGradient
                ?
                std::make_pair(0.,0.)
                :
@@ -67,7 +67,7 @@ namespace dealiiqc
       const double rm_by_r6 = rm6 / dealii::Utilities::fixed_power<3>(squared_distance);
 
       const double energy = eps * rm_by_r6 * ( rm_by_r6 - 2.);
-      const double force  = ComputeScalarForce
+      const double force  = ComputeGradient
                             ?
                             -12. * eps * rm_by_r6 * ( 1. - rm_by_r6) / sqrt(squared_distance)
                             :
@@ -78,15 +78,15 @@ namespace dealiiqc
 
     template
     std::pair<double, double>
-    PairLJCutManager::energy_and_scalar_force<true> ( const types::atom_type i_atom_type,
-                                                      const types::atom_type j_atom_type,
-                                                      const double &squared_distance) const;
+    PairLJCutManager::energy_and_gradient<true> (const types::atom_type i_atom_type,
+                                                 const types::atom_type j_atom_type,
+                                                 const double &squared_distance) const;
 
     template
     std::pair<double, double>
-    PairLJCutManager::energy_and_scalar_force<false> ( const types::atom_type i_atom_type,
-                                                       const types::atom_type j_atom_type,
-                                                       const double &squared_distance) const;
+    PairLJCutManager::energy_and_gradient<false> (const types::atom_type i_atom_type,
+                                                  const types::atom_type j_atom_type,
+                                                  const double &squared_distance) const;
 
   } // namespace Potential
 

--- a/source/qc/core.cc
+++ b/source/qc/core.cc
@@ -378,9 +378,9 @@ namespace dealiiqc
         // of atoms.
         const std::pair<double, double> pair =
           (*potential_ptr).template
-          energy_and_scalar_force<ComputeGradient> (cell_atom_I->second.type,
-                                                    cell_atom_J->second.type,
-                                                    r_square);
+          energy_and_gradient<ComputeGradient> (cell_atom_I->second.type,
+                                                cell_atom_J->second.type,
+                                                r_square);
 
         res += pair.first;
 

--- a/tests/potentials/pair_coul_wolf_01.cc
+++ b/tests/potentials/pair_coul_wolf_01.cc
@@ -29,7 +29,7 @@ void test ( const double &r,
                                   Potential::InteractionTypes::Coul_Wolf);
 
   const std::pair<double, double> energy_force_0 =
-    coul_wolf.energy_and_scalar_force( 0, 1, r*r);
+    coul_wolf.energy_and_gradient( 0, 1, r*r);
 
   std::cout << "Energy: " << energy_force_0.first << " "
             << "Force scalar: " << energy_force_0.second << std::endl;
@@ -40,7 +40,7 @@ void test ( const double &r,
                ExcInternalError());
 
   const std::pair<double, double> energy_force_1 =
-    coul_wolf.energy_and_scalar_force( 1, 0, r*r);
+    coul_wolf.energy_and_gradient( 1, 0, r*r);
 
   std::cout << "Energy: " << energy_force_1.first << " "
             << "Force scalar: " << energy_force_1.second << std::endl;
@@ -51,7 +51,7 @@ void test ( const double &r,
                ExcInternalError());
 
   const std::pair<double, double> energy_force_2 =
-    coul_wolf.energy_and_scalar_force<false>( 0, 1, r*r);
+    coul_wolf.energy_and_gradient<false>( 0, 1, r*r);
 
   std::cout << "Energy: " << energy_force_2.first << " "
             << "Force scalar: " << energy_force_2.second << std::endl;

--- a/tests/potentials/pair_coul_wolf_02.cc
+++ b/tests/potentials/pair_coul_wolf_02.cc
@@ -27,7 +27,7 @@ void test ( const double &r,
                                         Potential::InteractionTypes::Coul_Wolf);
 
   const std::pair<double, double> energy_force_0 =
-    coulf_wolf_ptr->energy_and_scalar_force( 0, 1, r*r);
+    coulf_wolf_ptr->energy_and_gradient( 0, 1, r*r);
 
   std::cout << "Energy: " << energy_force_0.first << " "
             << "Force scalar: " << energy_force_0.second << std::endl;
@@ -38,7 +38,7 @@ void test ( const double &r,
                ExcInternalError());
 
   const std::pair<double, double> energy_force_1 =
-    coulf_wolf_ptr->energy_and_scalar_force( 1, 0, r*r);
+    coulf_wolf_ptr->energy_and_gradient( 1, 0, r*r);
 
   std::cout << "Energy: " << energy_force_1.first << " "
             << "Force scalar: " << energy_force_1.second << std::endl;
@@ -49,7 +49,7 @@ void test ( const double &r,
                ExcInternalError());
 
   const std::pair<double, double> energy_force_2 =
-    coulf_wolf_ptr->energy_and_scalar_force<false>( 0, 1, r*r);
+    coulf_wolf_ptr->energy_and_gradient<false>( 0, 1, r*r);
 
   std::cout << "Energy: " << energy_force_2.first << " "
             << "Force scalar: " << energy_force_2.second << std::endl;

--- a/tests/potentials/pair_lj_cut_01.cc
+++ b/tests/potentials/pair_lj_cut_01.cc
@@ -16,19 +16,19 @@ void test ( const double &r, const double &cutoff_radius)
                            Potential::InteractionTypes::LJ,
                            lj_params);
   std::pair<double, double> energy_force_0 =
-    lj.energy_and_scalar_force( 0, 1, r*r);
+    lj.energy_and_gradient( 0, 1, r*r);
 
   std::cout << "Energy: " << energy_force_0.first << " "
             << "Force scalar: " << energy_force_0.second << std::endl;
 
   std::pair<double, double> energy_force_1 =
-    lj.energy_and_scalar_force( 1, 0, r*r);
+    lj.energy_and_gradient( 1, 0, r*r);
 
   std::cout << "Energy: " << energy_force_1.first << " "
             << "Force scalar: " << energy_force_1.second << std::endl;
 
   std::pair<double, double> energy_force_2 =
-    lj.energy_and_scalar_force<false>( 0, 1, r*r);
+    lj.energy_and_gradient<false>( 0, 1, r*r);
 
   std::cout << "Energy: " << energy_force_2.first << " "
             << "Force scalar: " << energy_force_2.second << std::endl;

--- a/tests/potentials/pair_lj_cut_02.cc
+++ b/tests/potentials/pair_lj_cut_02.cc
@@ -21,7 +21,7 @@ void test ( const double &r,
                            Potential::InteractionTypes::LJ,
                            lj_params);
   std::pair<double, double> energy_force_0 =
-    lj.energy_and_scalar_force( 0, 1, r*r);
+    lj.energy_and_gradient( 0, 1, r*r);
 
   AssertThrow( fabs(energy_force_0.first-lammps_energy) < 1e5 * std::numeric_limits<double>::epsilon(),
                ExcInternalError());
@@ -29,7 +29,7 @@ void test ( const double &r,
                ExcInternalError());
 
   std::pair<double, double> energy_force_1 =
-    lj.energy_and_scalar_force( 1, 0, r*r);
+    lj.energy_and_gradient( 1, 0, r*r);
 
   AssertThrow( fabs(energy_force_1.first-lammps_energy) < 1e5 * std::numeric_limits<double>::epsilon(),
                ExcInternalError());

--- a/tests/potentials/pair_lj_cut_03.cc
+++ b/tests/potentials/pair_lj_cut_03.cc
@@ -15,7 +15,7 @@ void test ( const double &r,
             std::shared_ptr<Potential::PairLJCutManager> lj_ptr)
 {
   std::pair<double, double> energy_force_0 =
-    lj_ptr->energy_and_scalar_force( 0, 1, r*r);
+    lj_ptr->energy_and_gradient( 0, 1, r*r);
 
   AssertThrow( fabs(energy_force_0.first-lammps_energy) < 1e5 * std::numeric_limits<double>::epsilon(),
                ExcInternalError());
@@ -23,7 +23,7 @@ void test ( const double &r,
                ExcInternalError());
 
   std::pair<double, double> energy_force_1 =
-    lj_ptr->energy_and_scalar_force( 1, 0, r*r);
+    lj_ptr->energy_and_gradient( 1, 0, r*r);
 
   AssertThrow( fabs(energy_force_1.first-lammps_energy) < 1e5 * std::numeric_limits<double>::epsilon(),
                ExcInternalError());


### PR DESCRIPTION
Also made spaces around keywords consistent.