### PR TITLE
facility to give hyper cube dimensions for the default triangulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ SET(TARGET_SRC
   source/io/configure_qc.cc
   source/io/data_out_atom_data.cc
   source/io/parse_atom_data.cc
+  source/io/geometry_base.cc
+  source/io/geometry_box.cc
+  source/io/geometry_gmsh.cc
   source/potentials/pair_base.cc
   source/potentials/pair_coul_wolf.cc
   source/potentials/pair_lj_cut.cc

--- a/include/dealiiqc/io/configure_qc.h
+++ b/include/dealiiqc/io/configure_qc.h
@@ -11,6 +11,8 @@
 #include <utility>
 #include <memory>
 
+#include <dealiiqc/io/geometry_box.h>
+#include <dealiiqc/io/geometry_gmsh.h>
 #include <dealiiqc/io/parse_atom_data.h>
 #include <dealiiqc/potentials/pair_lj_cut.h>
 #include <dealiiqc/potentials/pair_coul_wolf.h>
@@ -32,9 +34,9 @@ namespace dealiiqc
   public:
 
     /**
-     * Constructor with istream object
+     * Constructor with a shared pointer to an istream object @p is.
      */
-    ConfigureQC( std::shared_ptr<std::istream> );
+    ConfigureQC( std::shared_ptr<std::istream> is);
 
     /**
      * Get dimensionality of the problem
@@ -42,20 +44,24 @@ namespace dealiiqc
     unsigned int get_dimension() const;
 
     /**
-     * Get current mesh file
+     * Get a shared pointer to const dim dimensional Geometry object.
+     *
+     * The function returns one of #geometry_3d, #geometry_2d or #geometry_1d
+     * depending on the dimension provided in the input script while
+     * constructing the ConfigureQC object.
      */
-    std::string get_mesh_file() const;
+    template<int dim>
+    std::shared_ptr<const Geometry::Base<dim>> get_geometry () const;
 
     /**
-     * Get atom data file
+     * Get atom data file.
      */
     std::string get_atom_data_file() const;
 
     /**
-     * Get number of initial grid refinement cycles
+     * Get number of initial grid refinement cycles.
      */
     unsigned int get_n_initial_global_refinements() const;
-
 
     /**
      * Get input stream
@@ -70,12 +76,12 @@ namespace dealiiqc
     // TODO: take maximum_energy_radius from pair potential cutoff radii?
     // maximum_energy_radius= max{ cutoff_radii } + skin?
     /**
-     * Get maximum energy radius
+     * Get maximum energy radius.
      */
     double get_maximum_energy_radius() const;
 
     /**
-     * Get cluster radius
+     * Get cluster radius.
      */
     double get_cluster_radius() const;
 
@@ -87,7 +93,7 @@ namespace dealiiqc
   private:
 
     /*
-     * Declare parameters to configure qc
+     * Declare parameters to configure QC class.
      */
     static void declare_parameters( ParameterHandler &prm );
 
@@ -102,9 +108,29 @@ namespace dealiiqc
     unsigned int dimension;
 
     /**
-     * Path to the mesh file for initial qc setup.
+     * Shared pointer to the three dimensional Geometry object.
+     *
+     * @note The dimension of the Geometry object has to be read from the input
+     * stream, therefore in ConfigureQC class, shared pointers to all the three
+     * dimensioned Geometry object is declared. However, upon reading the input
+     * stream only the relevant shared pointer is initialized and the rest of
+     * the shared pointers are NULL.
      */
-    std::string mesh_file;
+    std::shared_ptr<const Geometry::Base<3>> geometry_3d;
+
+    /**
+     * Shared pointer to the two dimensional Geometry object.
+     *
+     * See note in #geometry_3d
+     */
+    std::shared_ptr<const Geometry::Base<2>> geometry_2d;
+
+    /**
+     * Shared pointer to the one dimensional Geometry object.
+     *
+     * See note in #geometry_3d
+     */
+    std::shared_ptr<const Geometry::Base<1>> geometry_1d;
 
     /**
      * Number of cycles of initial global refinement
@@ -118,7 +144,7 @@ namespace dealiiqc
 
     /**
      * Shared pointer to the input stream passed in to the
-     * constructor @see ConfigureQC().
+     * constructor ConfigureQC().
      */
     mutable std::shared_ptr<std::istream> input_stream;
 
@@ -132,30 +158,30 @@ namespace dealiiqc
      * to an atom, to identify whether the atom contributes to the
      * QC energy computations.
      *
-     * @p maximum_search_radius is also used to identify ghost cells of a
+     * #maximum_search_radius is also used to identify ghost cells of a
      * current MPI process. If any of a cell's vertices are within a
-     * @p maximum_search_radius distance from any of locally owned cell's vertices,
+     * #maximum_search_radius distance from any of locally owned cell's vertices,
      * then the cell is a ghost cell of a current MPI process.
      *
-     * @note @p maximum_search_radius should not be less than the sum of cluster
+     * @note #maximum_search_radius should not be less than the sum of cluster
      * radius and (maximum) cutoff radius.
      */
     double maximum_search_radius;
 
     /**
-     * @p maximum_energy_radius is the maximum of all the cutoff radii
+     * #maximum_energy_radius is the maximum of all the cutoff radii
      * of the pair potentials. It is used to update neighbor lists of
      * atoms.
      *
-     * @note @p maximum_search_radius is different from
-     * @p maximum_energy_radius. The former is used to identify ghost cells
+     * @note #maximum_search_radius is different from
+     * #maximum_energy_radius. The former is used to identify ghost cells
      * of a current MPI process, while the latter is used to update
      * neighbor lists of atoms.
      */
     double maximum_energy_radius;
 
     /**
-     * @p cluster_radius is the cluster radius used in QC
+     * The cluster radius used in QC.
      */
     double cluster_radius;
 

--- a/include/dealiiqc/io/geometry_base.h
+++ b/include/dealiiqc/io/geometry_base.h
@@ -1,0 +1,63 @@
+
+#ifndef __dealii_qc_geometry_base_h
+#define __dealii_qc_geometry_base_h
+
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/distributed/shared_tria.h>
+
+
+namespace dealiiqc
+{
+  using namespace dealii;
+
+  namespace Geometry
+  {
+
+    /**
+     * Declare geometry parameters in @p prm for all classes derived from Base.
+     */
+    void declare_parameters (ParameterHandler &prm);
+
+
+    /**
+     * Abstract base class to all geometric models.
+     */
+    template <int dim>
+    class Base
+    {
+    public:
+      /**
+       * Constructor
+       */
+      Base();
+
+      /**
+       * Destructor.
+       */
+      virtual ~Base();
+
+      /**
+       * Create a parallel::shared::Triangulation @p tria based on the chosen geometry.
+       */
+      virtual void create_coarse_mesh(parallel::shared::Triangulation<dim> &tria) const = 0;
+
+      /**
+       * Parse parameter stored in @p prm .
+       */
+      virtual void parse_parameters(ParameterHandler &prm) = 0;
+
+    };
+
+    /**
+     * Parse parameters stored in @p prm and return a geometry object.
+     */
+    template <int dim>
+    std::shared_ptr<const Base<dim> >
+    parse_parameters_and_get_geometry (ParameterHandler &prm);
+
+  } // namespace Geometry
+
+} // namespace dealiiqc
+
+
+#endif /* __dealii_qc_geometry_base_h */

--- a/include/dealiiqc/io/geometry_box.h
+++ b/include/dealiiqc/io/geometry_box.h
@@ -1,0 +1,55 @@
+
+#ifndef __dealii_qc_geometry_box_h
+#define __dealii_qc_geometry_box_h
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <dealiiqc/io/geometry_base.h>
+
+namespace dealiiqc
+{
+
+  namespace Geometry
+  {
+    /**
+     * Geometry defined by a box.
+     */
+    template <int dim>
+    class Box : public Base<dim>
+    {
+    public:
+
+      Box ();
+
+      virtual ~Box ();
+
+      virtual void create_coarse_mesh (dealii::parallel::shared::Triangulation<dim> &tria) const;
+
+      virtual void parse_parameters (ParameterHandler &prm);
+
+      static void declare_parameters (ParameterHandler &prm);
+
+    private:
+
+      /**
+       * Extent of the box in x-, y-, and z-direction (in 3d).
+       */
+      Point<dim> extents;
+
+      /**
+       * Center of the box in x, y, and z (in 3d) coordinates.
+       */
+      Point<dim> center;
+
+      /**
+       * The number of cells in each coordinate direction
+       */
+      unsigned int repetitions[dim];
+    };
+
+  } // namespace Geometry
+
+} // namespace dealiiqc
+
+#endif /* __dealii_qc_geometry_box_h */

--- a/include/dealiiqc/io/geometry_gmsh.h
+++ b/include/dealiiqc/io/geometry_gmsh.h
@@ -1,0 +1,46 @@
+
+#ifndef __dealii_qc_geometry_gmsh_h
+#define __dealii_qc_geometry_gmsh_h
+
+#include <deal.II/grid/grid_tools.h>
+
+#include <dealiiqc/io/geometry_base.h>
+
+namespace dealiiqc
+{
+  using namespace dealii;
+
+  namespace Geometry
+  {
+    /**
+     * Geometry defined by a Gmsh input file.
+     */
+    template <int dim>
+    class Gmsh : public Base<dim>
+    {
+    public:
+
+      Gmsh ();
+
+      virtual ~Gmsh ();
+
+      virtual void create_coarse_mesh (parallel::shared::Triangulation<dim> &tria) const;
+
+      virtual void parse_parameters (ParameterHandler &prm);
+
+      static void declare_parameters (ParameterHandler &prm);
+
+    private:
+
+      /**
+       * Path to the mesh.
+       */
+      std::string mesh_file;
+    };
+
+
+  } // namesapce Geometry
+
+} //namespace dealiiqc
+
+#endif /* __dealii_qc_geometry_gmsh_h */

--- a/source/io/geometry_base.cc
+++ b/source/io/geometry_base.cc
@@ -1,0 +1,86 @@
+
+#include <dealiiqc/io/geometry_base.h>
+#include <dealiiqc/io/geometry_box.h>
+#include <dealiiqc/io/geometry_gmsh.h>
+
+namespace dealiiqc
+{
+
+  using namespace dealii;
+
+  namespace Geometry
+  {
+
+
+    template <int dim>
+    Base<dim>::Base()
+    {}
+
+
+
+    template <int dim>
+    Base<dim>::~Base()
+    {}
+
+
+
+    // instantiation
+    template class Base<1>;
+    template class Base<2>;
+    template class Base<3>;
+
+
+
+    void declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        prm.declare_entry ("Type", "Box",
+                           Patterns::Selection ("Box|Gmsh"),
+                           "Domain geometry type.");
+      }
+      prm.leave_subsection();
+
+      // Goemetry::X<dim>::declare_parameters() is same for all dims
+      Geometry::Box<3>::declare_parameters(prm);
+      Geometry::Gmsh<3>::declare_parameters(prm);
+    }
+
+
+
+    template <int dim>
+    std::shared_ptr<const Base<dim> >
+    parse_parameters_and_get_geometry (ParameterHandler &prm)
+    {
+      std::string type;
+      std::shared_ptr<Base<dim> > geometry;
+      prm.enter_subsection("Geometry");
+      {
+        type = prm.get("Type");
+      }
+      prm.leave_subsection();
+
+      if (type == "Box")
+        geometry = std::make_shared<Geometry::Box<dim>>();
+      else if (type =="Gmsh")
+        geometry = std::make_shared<Geometry::Gmsh<dim>>();
+      else
+        AssertThrow(false, ExcInternalError());
+
+      geometry->parse_parameters(prm);
+
+      return std::const_pointer_cast<const Base<dim> >(geometry);
+    }
+
+
+
+    // instantiations:
+    template std::shared_ptr<const Geometry::Base<1> > parse_parameters_and_get_geometry<1> (ParameterHandler &);
+    template std::shared_ptr<const Geometry::Base<2> > parse_parameters_and_get_geometry<2> (ParameterHandler &);
+    template std::shared_ptr<const Geometry::Base<3> > parse_parameters_and_get_geometry<3> (ParameterHandler &);
+
+
+
+  } // namespace Geometry
+
+} // namespace dealiiqc

--- a/source/io/geometry_box.cc
+++ b/source/io/geometry_box.cc
@@ -1,0 +1,170 @@
+
+#include <dealiiqc/io/geometry_box.h>
+
+namespace dealiiqc
+{
+
+  using namespace dealii;
+
+  namespace Geometry
+  {
+
+
+
+    template <int dim>
+    Box<dim>::Box()
+      :
+      Base<dim>()
+    {}
+
+
+
+    template <int dim>
+    Box<dim>::~Box()
+    {}
+
+
+
+    template <int dim>
+    void Box<dim>::create_coarse_mesh (parallel::shared::Triangulation<dim> &coarse_grid) const
+    {
+      std::vector<unsigned int> rep_vec(repetitions, repetitions+dim);
+      Point<dim> bottom_left;
+      Point<dim> top_right;
+      for (unsigned int d=0; d < dim; d++)
+        {
+          bottom_left[d] = center[d] - extents[d]/2.;
+          top_right[d]   = center[d] + extents[d]/2.;
+        }
+      GridGenerator::subdivided_hyper_rectangle (coarse_grid,
+                                                 rep_vec,
+                                                 bottom_left,
+                                                 top_right,
+                                                 false);
+    }
+
+
+
+    template <>
+    void Box<1>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        prm.enter_subsection("Box");
+        {
+          center[0] = prm.get_double ("X center");
+          extents[0] = prm.get_double ("X extent");
+          repetitions[0] = prm.get_integer ("X repetitions");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    template <>
+    void Box<2>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        prm.enter_subsection("Box");
+        {
+          center[0] = prm.get_double ("X center");
+          extents[0] = prm.get_double ("X extent");
+          repetitions[0] = prm.get_integer ("X repetitions");
+
+          center[1] = prm.get_double ("Y center");
+          extents[1] = prm.get_double ("Y extent");
+          repetitions[1] = prm.get_integer ("Y repetitions");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    template <>
+    void Box<3>::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        prm.enter_subsection("Box");
+        {
+          center[0] = prm.get_double ("X center");
+          extents[0] = prm.get_double ("X extent");
+          repetitions[0] = prm.get_integer ("X repetitions");
+
+          center[1] = prm.get_double ("Y center");
+          extents[1] = prm.get_double ("Y extent");
+          repetitions[1] = prm.get_integer ("Y repetitions");
+
+          center[2] = prm.get_double ("Z center");
+          extents[2] = prm.get_double ("Z extent");
+          repetitions[2] = prm.get_integer ("Z repetitions");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    template <int dim>
+    void Box<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        prm.enter_subsection("Box");
+        {
+          prm.declare_entry ("X extent", "10",
+                             Patterns::Double (0),
+                             "Extent of the box in x-direction. Units: Angstrom.");
+          prm.declare_entry ("Y extent", "10",
+                             Patterns::Double (0),
+                             "Extent of the box in y-direction. Units: Angstrom.");
+          prm.declare_entry ("Z extent", "10",
+                             Patterns::Double (0),
+                             "Extent of the box in z-direction. This value is ignored "
+                             "if the simulation is in 2d. Units: Angstrom.");
+
+          prm.declare_entry ("X center", "0",
+                             Patterns::Double (),
+                             "Center of the box in x-direction. Units: Angstrom.");
+          prm.declare_entry ("Y center", "0",
+                             Patterns::Double (),
+                             "Center of the box in y-direction. Units: AnstromBohr.");
+          prm.declare_entry ("Z center", "0",
+                             Patterns::Double (),
+                             "Center of the box in z-direction. This value is ignored "
+                             "if the simulation is in 2d. Units: Angstrom.");
+
+          prm.declare_entry ("X repetitions", "1",
+                             Patterns::Integer (1),
+                             "Number of cells in X direction.");
+          prm.declare_entry ("Y repetitions", "1",
+                             Patterns::Integer (1),
+                             "Number of cells in Y direction.");
+          prm.declare_entry ("Z repetitions", "1",
+                             Patterns::Integer (1),
+                             "Number of cells in Z direction. This value is ignored "
+                             "if the simulation is in 2d.");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    // instantiation
+    template class Box<1>;
+    template class Box<2>;
+    template class Box<3>;
+
+  } // namespace Geometry
+
+} // namespace dealiiqc
+
+

--- a/source/io/geometry_gmsh.cc
+++ b/source/io/geometry_gmsh.cc
@@ -1,0 +1,88 @@
+
+#include <fstream>
+
+#include <deal.II/grid/grid_in.h>
+
+#include <dealiiqc/io/geometry_gmsh.h>
+
+namespace dealiiqc
+{
+
+  using namespace dealii;
+
+  namespace Geometry
+  {
+
+
+
+    template <int dim>
+    Gmsh<dim>::Gmsh()
+      :
+      Base<dim>()
+    {}
+
+
+
+    template <int dim>
+    Gmsh<dim>::~Gmsh()
+    {}
+
+
+
+    template <int dim>
+    void Gmsh<dim>::create_coarse_mesh (parallel::shared::Triangulation<dim> &coarse_grid) const
+    {
+      GridIn<dim> gridin;
+      gridin.attach_triangulation (coarse_grid);
+      std::ifstream mesh_stream (mesh_file.c_str());
+      gridin.read_msh (mesh_stream);
+    }
+
+
+
+    template <int dim>
+    void Gmsh<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        prm.enter_subsection("Gmsh");
+        {
+          mesh_file = prm.get("File");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    template <int dim>
+    void Gmsh<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry");
+      {
+        prm.enter_subsection("Gmsh");
+        {
+          prm.declare_entry ("File", "",
+                             Patterns::Anything (),
+                             "Input mesh file.");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    // instantiation
+    template class Gmsh<1>;
+    template class Gmsh<2>;
+    template class Gmsh<3>;
+
+
+  } // namespace Geometry
+
+} // namespace dealiiqc
+
+
+

--- a/source/qc/core.cc
+++ b/source/qc/core.cc
@@ -57,18 +57,8 @@ namespace dealiiqc
   template <int dim, typename PotentialType>
   void QC<dim, PotentialType>::setup_triangulation()
   {
-    if (!(configure_qc.get_mesh_file()).empty() )
-      {
-        const std::string meshfile = configure_qc.get_mesh_file();
-        GridIn<dim> gridin;
-        gridin.attach_triangulation( triangulation );
-        std::ifstream fin( meshfile );
-        gridin.read_msh(fin);
-      }
-    else
-      {
-        GridGenerator::hyper_cube (triangulation);
-      }
+    configure_qc.get_geometry<dim>()->create_coarse_mesh(triangulation);
+
     if ( configure_qc.get_n_initial_global_refinements() )
       triangulation.refine_global(configure_qc.get_n_initial_global_refinements());
   }

--- a/tests/io/geometry_box_01.cc
+++ b/tests/io/geometry_box_01.cc
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <sstream>
+
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/grid/grid_out.h>
+
+#include <dealiiqc/io/configure_qc.h>
+#include <dealiiqc/utilities.h>
+
+using namespace dealii;
+using namespace dealiiqc;
+
+// Short test to check Geometry::Box<dim>::create_coarse_mesh()
+
+
+template<int dim>
+void test (const MPI_Comm &mpi_communicator, const ConfigureQC &config)
+{
+  parallel::shared::Triangulation<dim> tria (mpi_communicator,
+                                             Triangulation<dim>::limit_level_difference_at_vertices);
+
+  config.get_geometry<dim>()->create_coarse_mesh(tria);
+
+  GridOut grid_out;
+  grid_out.write_vtk (tria, std::cout);
+}
+
+
+int main (int argc, char **argv)
+{
+  try
+    {
+      dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization( argc,
+          argv,
+          numbers::invalid_unsigned_int);
+      std::ostringstream oss;
+      oss
+          << "set Dimension = 3"                              << std::endl
+          << "subsection Geometry"                            << std::endl
+          << "  set Type = Box"                               << std::endl
+          << "end"                                            << std::endl
+          << "#end-of-parameter-section" << std::endl;
+
+
+      std::shared_ptr<std::istream> prm_stream =
+        std::make_shared<std::istringstream>(oss.str().c_str());
+
+
+      ConfigureQC config( prm_stream );
+
+      test<3>(MPI_COMM_WORLD, config);
+
+
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      throw;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      throw;
+    }
+
+  return 0;
+}

--- a/tests/io/geometry_box_01.output
+++ b/tests/io/geometry_box_01.output
@@ -1,0 +1,36 @@
+# vtk DataFile Version 3.0
+#This file was generated 
+ASCII
+DATASET UNSTRUCTURED_GRID
+
+POINTS 8 double
+-5 -5 -5
+5 -5 -5
+-5 5 -5
+5 5 -5
+-5 -5 5
+5 -5 5
+-5 5 5
+5 5 5
+
+CELLS 1 9
+8	0	1	3	2	4	5	7	6
+
+CELL_TYPES 1
+ 12
+POINT_DATA 8
+SCALARS level double 1
+LOOKUP_TABLE default
+0 0 0 0 0 0 0 0 
+SCALARS manifold double 1
+LOOKUP_TABLE default
+-1 -1 -1 -1 -1 -1 -1 -1 
+SCALARS material double 1
+LOOKUP_TABLE default
+0 0 0 0 0 0 0 0 
+SCALARS subdomain double 1
+LOOKUP_TABLE default
+0 0 0 0 0 0 0 0 
+SCALARS level_subdomain double 1
+LOOKUP_TABLE default
+0 0 0 0 0 0 0 0 


### PR DESCRIPTION
The instance where a mesh file isn't provided is actually quite useful than I thought in the beginning. However, if we could pass hyper cube dimensions where we generate the triangulation it could be helpful. A lot of QC simulations could just use a `hyper_cube` at least at the current stage that we are in.