### PR TITLE
fix parse atom data tests

### DIFF
--- a/tests/atom/atom_handler_parse_atoms_01.cc
+++ b/tests/atom/atom_handler_parse_atoms_01.cc
@@ -5,7 +5,7 @@
 #include <deal.II/grid/grid_generator.h>
 
 #include <dealiiqc/atom/atom_handler.h>
-#include <dealiiqc/io/configure_qc.h>
+#include <dealiiqc/configure/configure_qc.h>
 #include <dealiiqc/utilities.h>
 
 using namespace dealii;
@@ -33,6 +33,12 @@ public:
     GridGenerator::hyper_cube( triangulation, 0., 8., true );
     triangulation.refine_global (1);
     AtomHandler<dim>::parse_atoms_and_assign_to_cells( dof_handler, atom_data);
+
+    // Check that the number of atoms picked up and added to energy_atoms
+    // is so and so and shouldn't change each time this test is run.
+    std::cout << "The number of energy atoms picked up : "
+              << atom_data.energy_atoms.size()
+              << std::endl;
   }
 
 private:

--- a/tests/atom/atom_handler_parse_atoms_01.output
+++ b/tests/atom/atom_handler_parse_atoms_01.output
@@ -1,1 +1,2 @@
+The number of energy atoms picked up : 218
 OK

--- a/tests/atom/parse_atom_data_01.cc
+++ b/tests/atom/parse_atom_data_01.cc
@@ -4,10 +4,58 @@
 #include <sstream>
 #include <deal.II/base/conditional_ostream.h>
 
-#include <dealiiqc/qc.h>
+#include <dealiiqc/atom/parse_atom_data.h>
+#include <dealiiqc/configure/configure_qc.h>
 
 using namespace dealii;
 using namespace dealiiqc;
+
+// A class to test ParseAtomData's central function parse
+template <int dim>
+void test_parse(const MPI_Comm &mpi_communicator, std::istream &is)
+{
+  unsigned int n_mpi_processes(dealii::Utilities::MPI::n_mpi_processes(mpi_communicator)),
+               this_mpi_process(dealii::Utilities::MPI::this_mpi_process(mpi_communicator));
+
+  std::vector<Atom<dim>> atoms;
+  std::vector<dealiiqc::types::charge> charges;
+  std::vector<double> masses;
+
+  ParseAtomData<dim> parsing_object;
+
+  parsing_object.parse(is, atoms, charges, masses);
+
+  for(unsigned int p = 0; p < n_mpi_processes; ++p)
+    {
+      MPI_Barrier(mpi_communicator);
+
+      if (p==this_mpi_process)
+        {
+          // Check that the number of atoms, charges and masses parsed and added
+          // are same each time we run this test.
+          std::cout << "This is process: " << p << std::endl
+
+                    << "The number of atoms parsed: " << atoms.size()
+                    << std::endl
+
+                    << "The number of different charged atom types parsed: "
+                    << charges.size()
+                    << std::endl
+
+                    << "The number of different atom types parsed: "
+                    << masses.size()
+                    << std::endl;
+
+
+          // For this particular test case all different atom types are charged.
+          AssertThrow (charges.size()==masses.size(),
+                       ExcInternalError());
+        }
+
+      MPI_Barrier(mpi_communicator);
+    }
+
+};
 
 int main( int argc, char **argv)
 {
@@ -16,25 +64,20 @@ int main( int argc, char **argv)
       dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization( argc, argv, numbers::invalid_unsigned_int);
       std::ostringstream oss;
       oss
-          << "set Dimension = 3"                              << std::endl
-          << "subsection Configure mesh"                      << std::endl
-          << "  set Mesh file = "                             << SOURCE_DIR
-          << "/../data/refined_cube.msh"                      << std::endl
-          << "  set Number of initial global refinements = 1" << std::endl
-          << "end"                                            << std::endl
-          << "subsection Configure atoms"                     << std::endl
-          << "  set Atom data file = "                        << SOURCE_DIR
-          << "/../data/16_NaCl_atom.data"                     << std::endl
-          << "end"                                            << std::endl;
+          << "set Dimension = 3"                                  << std::endl
+          << "subsection Configure atoms"                         << std::endl
+          << "  set Atom data file = " << SOURCE_DIR "/../data/16_NaCl_atom.data" << std::endl
+          << "end"                                                << std::endl;
 
       std::shared_ptr<std::istream> prm_stream =
         std::make_shared<std::istringstream>(oss.str().c_str());
 
       ConfigureQC config( prm_stream );
-      // Allow the restriction that user must provide Dimension of the problem
-      const unsigned int dim = config.get_dimension();
 
-      QC<3> problem( config );
+      const std::string atom_data_file = config.get_atom_data_file();
+      std::fstream fin (atom_data_file, std::fstream::in);
+
+      test_parse<3>(MPI_COMM_WORLD, fin);
     }
   catch (std::exception &exc)
     {

--- a/tests/atom/parse_atom_data_01.mpirun=3.output
+++ b/tests/atom/parse_atom_data_01.mpirun=3.output
@@ -1,0 +1,12 @@
+This is process: 0
+The number of atoms parsed: 4096
+The number of different charged atom types parsed: 2
+The number of different atom types parsed: 2
+This is process: 1
+The number of atoms parsed: 4096
+The number of different charged atom types parsed: 2
+The number of different atom types parsed: 2
+This is process: 2
+The number of atoms parsed: 4096
+The number of different charged atom types parsed: 2
+The number of different atom types parsed: 2


### PR DESCRIPTION
Reworked two tests on parsing atom data file. 
The second test `parse_atom_data_01`  is reworked heavily to output some atom information. The blessed output is changed accordingly.

Edit: This is partly due to #71 and partly because they could be improved.