### PR TITLE
Rename/max search radius

### DIFF
--- a/source/atom/atom_handler.cc
+++ b/source/atom/atom_handler.cc
@@ -77,11 +77,11 @@ namespace dealiiqc
     // the size of ghost_cells vector is zero.
     const std::vector<typename types::MeshType<dim>::active_cell_iterator> ghost_cells =
       GridTools::compute_ghost_cell_layer_within_distance( mesh,
-                                                           configure_qc.get_maximum_search_radius());
+                                                           configure_qc.get_ghost_cell_layer_thickness());
 
     // Loop through all the ghost cells computed above and
-    // Mark (true) all the vertices of the active ghost cells within
-    // a maximum search radius.
+    // Mark (true) all the vertices of the locally owned and active
+    // ghost cells within ConfigureQC::ghost_cell_layer_thickness.
     // Also, initialize n_thrown_atoms_per_cell.
     for ( auto cell : ghost_cells)
       {
@@ -91,8 +91,8 @@ namespace dealiiqc
       }
 
     // TODO: If/when required collect all non-relevant atoms
-    // (those that are not within a maximum search radius
-    //  for this MPI process energy computation)
+    // (those that are not within a ConfigureQC::ghost_cell_layer_thickness
+    // for this MPI process energy computation)
     // For now just add the number of atoms being thrown.
     types::global_atom_index n_thrown_atoms=0;
 
@@ -124,7 +124,7 @@ namespace dealiiqc
             atom.reference_position = GeometryInfo<dim>::project_to_unit_cell(my_pair.second);
             // TODO: Remove parent_cell
             atom.parent_cell = my_pair.first;
-            if ( Utilities::is_point_within_distance_from_cell_vertices( atom.position, my_pair.first, configure_qc.get_maximum_search_radius() ))
+            if ( Utilities::is_point_within_distance_from_cell_vertices( atom.position, my_pair.first, configure_qc.get_ghost_cell_layer_thickness() ))
               {
                 atom_associated_to_cell = true;
                 energy_atoms.insert( std::make_pair( my_pair.first, atom ));

--- a/tests/atom/atom_handler_cluster_weight_01.cc
+++ b/tests/atom/atom_handler_cluster_weight_01.cc
@@ -70,7 +70,7 @@ int main (int argc, char **argv)
           << "  set Maximum energy radius = 1.9"            << std::endl
           << "end"                                          << std::endl
           << "subsection Configure QC"                      << std::endl
-          << "  set Max search radius = 1.9"                << std::endl
+          << "  set Ghost cell layer thickness = 1.9"       << std::endl
           << "  set Cluster radius = 1.9"                   << std::endl
           << "  set Cluster weights by type = Cell"         << std::endl
           << "end"                                          << std::endl

--- a/tests/atom/atom_handler_cluster_weight_02.cc
+++ b/tests/atom/atom_handler_cluster_weight_02.cc
@@ -75,7 +75,7 @@ int main (int argc, char **argv)
           << "  set Maximum energy radius = 9"              << std::endl
           << "end"                                          << std::endl
           << "subsection Configure QC"                      << std::endl
-          << "  set Max search radius = 9"                  << std::endl
+          << "  set Ghost cell layer thickness = 9"         << std::endl
           << "  set Cluster radius = 9"                     << std::endl
           << "  set Cluster weights by type = Cell"         << std::endl
           << "end"                                          << std::endl

--- a/tests/atom/atom_handler_neigh_list_01.cc
+++ b/tests/atom/atom_handler_neigh_list_01.cc
@@ -65,7 +65,7 @@ int main (int argc, char **argv)
           << "  set Maximum energy radius = 16.0"             << std::endl
           << "end"                                            << std::endl
           << "subsection Configure QC"                        << std::endl
-          << "  set Max search radius = 2.0"                  << std::endl
+          << "  set Ghost cell layer thickness = 2."          << std::endl
           << "  set Cluster radius = 4.0"                     << std::endl
           << "end"                                            << std::endl
           << "#end-of-parameter-section" << std::endl

--- a/tests/atom/atom_handler_parse_atoms_01.cc
+++ b/tests/atom/atom_handler_parse_atoms_01.cc
@@ -60,10 +60,10 @@ int main (int argc, char **argv)
           << "set Dimension = 3"                              << std::endl
           << "subsection Configure atoms"                     << std::endl
           << "  set Atom data file = "
-          << SOURCE_DIR "/../data/8_NaCl_atom.data"          << std::endl
+          << SOURCE_DIR "/../data/8_NaCl_atom.data"           << std::endl
           << "end" << std::endl
           << "subsection Configure QC"                        << std::endl
-          << "  set Max search radius = 2.0"                  << std::endl
+          << "  set Ghost cell layer thickness = 2"           << std::endl
           << "end" << std::endl;
 
       std::shared_ptr<std::istream> prm_stream =

--- a/tests/atom/atom_handler_thrown_atoms_01.cc
+++ b/tests/atom/atom_handler_thrown_atoms_01.cc
@@ -68,10 +68,10 @@ int main (int argc, char **argv)
       std::ostringstream oss;
       oss << "set Dimension = 3"                              << std::endl
           << "subsection Configure atoms"                     << std::endl
-          << "  set Maximum energy radius = 1.1"             << std::endl
+          << "  set Maximum energy radius = 1.1"              << std::endl
           << "end"                                            << std::endl
           << "subsection Configure QC"                        << std::endl
-          << "  set Max search radius = 1.9"                  << std::endl
+          << "  set Ghost cell layer thickness = 1.9"         << std::endl
           << "  set Cluster radius = 1.1"                     << std::endl
           << "end"                                            << std::endl
           << "#end-of-parameter-section" << std::endl

--- a/tests/atom/atom_handler_thrown_atoms_02.cc
+++ b/tests/atom/atom_handler_thrown_atoms_02.cc
@@ -64,7 +64,7 @@ int main (int argc, char **argv)
           << "  set Maximum energy radius = 16.0"             << std::endl
           << "end"                                            << std::endl
           << "subsection Configure QC"                        << std::endl
-          << "  set Max search radius = 2.0"                  << std::endl
+          << "  set Ghost cell layer thickness = 2."          << std::endl
           << "  set Cluster radius = 4.0"                     << std::endl
           << "end"                                            << std::endl;
 

--- a/tests/atom/write_atom_data_into_vtp_01.cc
+++ b/tests/atom/write_atom_data_into_vtp_01.cc
@@ -120,7 +120,7 @@ int main (int argc, char **argv)
           << SOURCE_DIR "/../data/16_NaCl_atom.data"          << std::endl
           << "end" << std::endl
           << "subsection Configure QC"                        << std::endl
-          << "  set Max search radius = 1.1"                  << std::endl
+          << "  set Ghost cell layer thickness = 1.1"         << std::endl
           << "end" << std::endl;
 
       std::shared_ptr<std::istream> prm_stream =

--- a/tests/core/energy_coul_wolf_01.cc
+++ b/tests/core/energy_coul_wolf_01.cc
@@ -94,7 +94,7 @@ int main (int argc, char *argv[])
           << "end"                                            << std::endl
 
           << "subsection Configure QC"                        << std::endl
-          << "  set Max search radius = 2.0"                  << std::endl
+          << "  set Ghost cell layer thickness = 2."          << std::endl
           << "  set Cluster radius = 2.0"                     << std::endl
           << "end"                                            << std::endl
           << "#end-of-parameter-section"                      << std::endl

--- a/tests/core/energy_coul_wolf_02.cc
+++ b/tests/core/energy_coul_wolf_02.cc
@@ -154,7 +154,7 @@ int main (int argc, char *argv[])
           << "end"                                            << std::endl
 
           << "subsection Configure QC"                        << std::endl
-          << "  set Max search radius = 2.25"                 << std::endl
+          << "  set Ghost cell layer thickness = 2.25"        << std::endl
           << "  set Cluster radius = 2.0"                     << std::endl
           << "end"                                            << std::endl
           << "#end-of-parameter-section"                      << std::endl

--- a/tests/core/energy_coul_wolf_03.cc
+++ b/tests/core/energy_coul_wolf_03.cc
@@ -122,7 +122,7 @@ int main (int argc, char *argv[])
           << "end"                                            << std::endl
 
           << "subsection Configure QC"                        << std::endl
-          << "  set Max search radius = 100"                  << std::endl
+          << "  set Ghost cell layer thickness = 100."        << std::endl
           << "  set Cluster radius = 100"                     << std::endl
           << "end"                                            << std::endl
           << "#end-of-parameter-section"                      << std::endl;

--- a/tests/core/energy_coul_wolf_04.cc
+++ b/tests/core/energy_coul_wolf_04.cc
@@ -154,7 +154,7 @@ int main (int argc, char *argv[])
           << "end"                                            << std::endl
 
           << "subsection Configure QC"                        << std::endl
-          << "  set Max search radius = 2.0"                  << std::endl
+          << "  set Ghost cell layer thickness = 2."          << std::endl
           << "  set Cluster radius = 1.0"                     << std::endl
           << "end"                                            << std::endl
           << "#end-of-parameter-section"                      << std::endl


### PR DESCRIPTION
The label `max_search_radius` is not intuitive and descriptive enough. Changing it to `ghost_cell_layer_thickness`. The second commit updates the tests with this changed name.