### PR TITLE
Move cluster weights calculation from setup_atom_data to run function

### DIFF
--- a/include/deal.II-qc/core/qc.h
+++ b/include/deal.II-qc/core/qc.h
@@ -75,14 +75,18 @@ namespace dealiiqc
      * AtomData::energy_atoms which holds an association between the locally
      * relevant active cell of the underlying #triangulation and the energy
      * atoms in it.
+     */
+    void setup_atom_data();
+
+    /**
+     * Setup cluster weights of the AtomData::energy_atoms in #atom_data.
      *
-     * This function also updates cluster weights of the AtomData::energy_atoms
-     * in #atom_data. All cluster atoms get a non zero cluster weight while the
+     * All cluster atoms get a non zero cluster weight while the
      * other energy atoms get a zero cluster weight. #configure_qc creates a
      * shared pointer to the derived class of Cluster::WeightsByBase based on
      * the chosen method to update cluster weights of cluster atoms.
      */
-    void setup_atom_data();
+    void setup_cluster_weights();
 
     /**
      * Distribute degrees-of-freedom and initialise matrices and vectors.

--- a/source/core/qc.cc
+++ b/source/core/qc.cc
@@ -45,13 +45,11 @@ namespace dealiiqc
   {
     Assert( dim==configure_qc.get_dimension(), ExcInternalError());
 
-    // Load the mesh by reading from mesh file
+    // Load the mesh by reading from mesh file.
     setup_triangulation();
 
-    // Read atom data file and initialize atoms
+    // Read atom data file and initialize atoms.
     setup_atom_data();
-
-    setup_system();
 
   }
 
@@ -77,7 +75,13 @@ namespace dealiiqc
     // object. However, charges in PotentialType object aren't set yet.
     // Finish setting up PotentialType object here.
     configure_qc.get_potential()->set_charges(atom_data.charges);
+  }
 
+
+
+  template <int dim, typename PotentialType>
+  void QC<dim, PotentialType>::setup_cluster_weights()
+  {
     // It is ConfigureQC that actually creates a shared pointer to the derived
     // class object of the Cluster::WeightsByBase according to the parsed input.
     configure_qc.get_cluster_weights<dim>()->
@@ -457,6 +461,8 @@ namespace dealiiqc
   template <int dim, typename PotentialType>
   void QC<dim, PotentialType>::run ()
   {
+    setup_cluster_weights();
+    setup_system();
     setup_fe_values_objects();
     update_neighbor_lists();
     update_energy_atoms_positions();


### PR DESCRIPTION
Separating calculation of `cluster_weights` of energy atoms from the `QC` constructor. By doing this, one could change `cluster_radius` intermittently and perform `QC::run()` again on reconfigured QC system.