### PR TITLE
Restructure/atom parsing and associations

### DIFF
--- a/include/deal.II-qc/atom/atom_data.h
+++ b/include/deal.II-qc/atom/atom_data.h
@@ -69,30 +69,28 @@ namespace dealiiqc
     std::vector<double> masses;
 
     /**
-     * A lookup data structure for all atoms in the system needed by a
-     * current MPI core, namely a union of locally owned and ghost atoms.
-     * Used for initializing cell based data structures that would actually be
-     * used for computations.
+     * The cell based data structure that contains cells and atoms association
+     * for all the atoms in the system. The function
+     * AtomHandler::parse_atoms_and_assign_to_cells() is responsible for
+     * updating this data member.
      *
-     * The following optimization technique is employed while adding energy
-     * atoms. For each atom in the system, before going over all locally owned
+     * The following optimization technique is employed while adding atoms.
+     * For each atom in the system, before going over all locally owned
      * cells to find if the atom lies within it, we can first check whether the
      * atom's location lies inside the bounding box of the current processor's
      * set of locally relevant cells.
      */
-    std::multimap<types::CellIteratorType<dim>, Atom<dim>> energy_atoms;
+    types::CellAtomContainerType<dim> atoms;
 
+    // TODO: * The function QC::setup_energy_atoms() is responsible for
+    //       * updating this data member.
     /**
-     * The number of locally relevant non-energy atoms per cell.
-     * This is exactly the number of non-energy atoms for whom a
-     * locally relevant cell is found while updating #energy_atoms.
-     * They were thrown because they weren't energy atoms.
-     *
-     * @note The map also contains the information of number of
-     * thrown atoms per cell for ghost cells on the current
-     * MPI process.
+     * The cell based data structure that contains cells and energy atoms
+     * association for all the energy atoms in the system needed by a
+     * current MPI core. This data member contains the central information for
+     * energy and force computations.
      */
-    std::map<types::CellIteratorType<dim>, unsigned int> n_thrown_atoms_per_cell;
+    types::CellAtomContainerType<dim> energy_atoms;
 
   };
 

--- a/include/deal.II-qc/atom/atom_handler.h
+++ b/include/deal.II-qc/atom/atom_handler.h
@@ -27,28 +27,25 @@ namespace dealiiqc
     AtomHandler( const ConfigureQC &configure_qc);
 
     /**
-     * Setup cell based atom attributes in @p atom_data,  namely:
-     * AtomData::energy_atoms, AtomData::masses and AtomData::atomtype_to_atoms.
+     * Setup few data members in AtomData (namely: AtomData::atoms,
+     * AtomData::masses and AtomData::atomtype_to_atoms) by parsing the atom
+     * data information provided through #configure_qc. This function does not
+     * update AtomData::energy_atoms.
      *
      * For each and every atom in the system, find the locally relevant cell
      * of the @p mesh which surrounds it. If the atom doesn't belong to
      * any of the locally relevant cells, it is thrown. In the case when
-     * a locally relevant cell is found, and if the atom is energy atom it is
-     * inserted into AtomData::energy_atoms.
+     * a locally relevant cell is found is is inserted into AtomData::atoms.
      *
      * A locally relevant cell is one which is either a locally owned cell or
-     * a ghost cell within a certain distance(determined by interaction radius
-     * between atoms in the system). A ghost cell could contain atoms whose
+     * a ghost cell within a ConfigureQC::ghost_cell_layer_thickness from the
+     * locally owned cell. A ghost cell could contain atoms whose
      * positions are needed for computing energy or forces on locally owned
      * cluster atoms. An MPI process computes energy and forces only of it's
      * locally relevant cluster atoms.
      *
-     * All the atoms which are not locally relevant energy_atoms
-     * are thrown away. However, a count of the number of (locally relevant)
-     * non-energy atoms (i.e., for which a locally relevant cell is found
-     * but are not energy atoms) is kept using AtomData::n_thrown_atoms_per_cell
-     * for the sake of updating cluster weights at a later stage.
-     *
+     * All the atoms which are outside the locally relevant cells are thrown
+     * away.
      */
     void parse_atoms_and_assign_to_cells( const types::MeshType<dim> &mesh,
                                           AtomData<dim> &atom_data) const;

--- a/source/configure/configure_qc.cc
+++ b/source/configure/configure_qc.cc
@@ -91,7 +91,7 @@ namespace dealiiqc
       // we either need to make ConfigureQC templated with dim, or keep around
       // three different shared pointers.
       return std::make_shared<const Cluster::WeightsByCell<dim> >
-             (cluster_radius);
+             (cluster_radius, maximum_cutoff_radius);
     else
       AssertThrow (false, ExcInternalError());
 

--- a/source/core/qc.cc
+++ b/source/core/qc.cc
@@ -70,7 +70,7 @@ namespace dealiiqc
   {
     // TODO: Change timer description
     TimerOutput::Scope t (computing_timer, "Parse atom data and associate atoms with cells");
-    atom_handler.parse_atoms_and_assign_to_cells( dof_handler, atom_data);
+    atom_handler.parse_atoms_and_assign_to_cells (dof_handler, atom_data);
 
     // It is ConfigureQC that actually creates a PotentialType object according
     // to the parsed input and can return a shared pointer to the PotentialType
@@ -80,9 +80,10 @@ namespace dealiiqc
 
     // It is ConfigureQC that actually creates a shared pointer to the derived
     // class object of the Cluster::WeightsByBase according to the parsed input.
-    configure_qc.get_cluster_weights<dim>()->
-    update_cluster_weights (atom_data.n_thrown_atoms_per_cell,
-                            atom_data.energy_atoms);
+    atom_data.energy_atoms =
+      configure_qc.get_cluster_weights<dim>()->
+      update_cluster_weights (dof_handler,
+                              atom_data.atoms);
   }
 
 


### PR DESCRIPTION
- `AtomData` has new data members `atoms` and `n_atoms_per_vertex`.
- `AtomHandler<dim>::parse_atoms_and_assign_to_cells` populates `atoms`.
- `Atomhandler::update_energy_atoms` updates `energy_atoms`.

I will rebase the commits in this PR and force push as soon as #99 is closed.