### PR TITLE
reconfigure_qc function added

### DIFF
--- a/include/deal.II-qc/atom/atom_data.h
+++ b/include/deal.II-qc/atom/atom_data.h
@@ -82,13 +82,14 @@ namespace dealiiqc
      */
     types::CellAtomContainerType<dim> atoms;
 
-    // TODO: * The function QC::setup_energy_atoms() is responsible for
-    //       * updating this data member.
     /**
      * The cell based data structure that contains cells and energy atoms
      * association for all the energy atoms in the system needed by a
      * current MPI core. This data member contains the central information for
      * energy and force computations.
+     *
+     * The function QC::setup_energy_atoms_with_cluster_weights() is
+     * responsible for updating this data member.
      */
     types::CellAtomContainerType<dim> energy_atoms;
 

--- a/source/atom/cluster_weights.cc
+++ b/source/atom/cluster_weights.cc
@@ -87,7 +87,7 @@ namespace dealiiqc
       // if so if it's a cluster atom.
       // While there, count the total number of atoms per cell and
       // number of cluster atoms per cell.
-      for (const auto & cell_atom : atoms)
+      for (const auto &cell_atom : atoms)
         {
           const auto &cell = cell_atom.first;
           Atom<dim> atom   = cell_atom.second;
@@ -137,9 +137,9 @@ namespace dealiiqc
           // The cluster weight was previously set to 1. if the atom is
           // cluster atom and 0. if the atom is not cluster atom.
           energy_atom.second.cluster_weight *=
-              n_atoms_per_cell.at(energy_atom.first)
-              /
-              n_cluster_atoms_per_cell.at(energy_atom.first);
+            n_atoms_per_cell.at(energy_atom.first)
+            /
+            n_cluster_atoms_per_cell.at(energy_atom.first);
         }
 
       return energy_atoms;


### PR DESCRIPTION
For restarting QC simulation without parsing and assigning all the atoms to cells again.