### PR TITLE
fix cluster weights test involving change of blessed file

### DIFF
--- a/tests/atom/atom_handler_cluster_weight_01.output
+++ b/tests/atom/atom_handler_cluster_weight_01.output
@@ -1,2 +1,10 @@
+Atom: 2 2 2 Cluster_Weight: 0
+Atom: 6 2 2 Cluster_Weight: 0
+Atom: 2 6 2 Cluster_Weight: 0
+Atom: 2 2 6 Cluster_Weight: 0
+Atom: 6 6 2 Cluster_Weight: 0
+Atom: 6 2 6 Cluster_Weight: 0
+Atom: 2 6 6 Cluster_Weight: 0
+Atom: 6 6 6 Cluster_Weight: 0
 Atom: 7 7 7.9 Cluster_Weight: 5
 Atom: 1 1 0.1 Cluster_Weight: 5


### PR DESCRIPTION
Had to change the blessed output because of a previous bug that energy atoms where updated using `ghost_cell_layer_thickness`. With the bugfix the output should be different. The test `.cc` file is also modified slightly in reference to #108.