### PR TITLE
fix tests in core

### DIFF
--- a/tests/core/energy_coul_wolf_01.cc
+++ b/tests/core/energy_coul_wolf_01.cc
@@ -35,13 +35,15 @@ Problem<dim, PotentialType>::Problem (const ConfigureQC &config)
 template <int dim, typename PotentialType>
 void Problem<dim, PotentialType>::partial_run(const double &blessed_energy)
 {
+  QC<dim, PotentialType>::setup_energy_atoms_with_cluster_weights();
+  QC<dim, PotentialType>::setup_system();
+  QC<dim, PotentialType>::setup_fe_values_objects();
+  QC<dim, PotentialType>::update_neighbor_lists();
+
   QC<dim, PotentialType>::pcout
       << "The number of energy atoms in the system: "
       << QC<dim, PotentialType>::atom_data.energy_atoms.size()
       << std::endl;
-
-  QC<dim, PotentialType>::setup_fe_values_objects();
-  QC<dim, PotentialType>::update_neighbor_lists();
 
   QC<dim, PotentialType>::pcout << "Neighbor lists: " << std::endl;
 

--- a/tests/core/energy_coul_wolf_02.cc
+++ b/tests/core/energy_coul_wolf_02.cc
@@ -62,6 +62,11 @@ void Problem<dim, PotentialType>::partial_run(const double &blessed_energy)
   unsigned int n_mpi_processes(dealii::Utilities::MPI::n_mpi_processes(QC<dim, PotentialType>::mpi_communicator)),
            this_mpi_process(dealii::Utilities::MPI::this_mpi_process(QC<dim, PotentialType>::mpi_communicator));
 
+  QC<dim, PotentialType>::setup_energy_atoms_with_cluster_weights();
+  QC<dim, PotentialType>::setup_system();
+  QC<dim, PotentialType>::setup_fe_values_objects();
+  QC<dim, PotentialType>::update_neighbor_lists();
+
   for (unsigned int p = 0; p < n_mpi_processes; p++)
     {
       MPI_Barrier(QC<dim, PotentialType>::mpi_communicator);
@@ -74,8 +79,6 @@ void Problem<dim, PotentialType>::partial_run(const double &blessed_energy)
       MPI_Barrier(QC<dim, PotentialType>::mpi_communicator);
     }
 
-  QC<dim, PotentialType>::setup_fe_values_objects();
-  QC<dim, PotentialType>::update_neighbor_lists();
   const double energy = QC<dim, PotentialType>::template
                         calculate_energy_gradient<false> (QC<dim, PotentialType>::gradient);
 

--- a/tests/core/energy_coul_wolf_03.cc
+++ b/tests/core/energy_coul_wolf_03.cc
@@ -39,6 +39,10 @@ Problem<dim, PotentialType>::Problem (const ConfigureQC &config)
 template <int dim, typename PotentialType>
 void Problem<dim, PotentialType>::partial_run(const double &blessed_energy)
 {
+  QC<dim, PotentialType>::setup_energy_atoms_with_cluster_weights();
+  QC<dim, PotentialType>::setup_system();
+  QC<dim, PotentialType>::setup_fe_values_objects();
+  QC<dim, PotentialType>::update_neighbor_lists();
 
   unsigned int n_mpi_processes(dealii::Utilities::MPI::n_mpi_processes(QC<dim, PotentialType>::mpi_communicator)),
            this_mpi_process(dealii::Utilities::MPI::this_mpi_process(QC<dim, PotentialType>::mpi_communicator));
@@ -55,9 +59,6 @@ void Problem<dim, PotentialType>::partial_run(const double &blessed_energy)
     }
   MPI_Barrier(QC<dim, PotentialType>::mpi_communicator);
 
-  QC<dim, PotentialType>::setup_fe_values_objects();
-  QC<dim, PotentialType>::update_neighbor_lists();
-
   const double energy = QC<dim, PotentialType>::template
                         calculate_energy_gradient<false> (QC<dim, PotentialType>::gradient);
 
@@ -67,7 +68,6 @@ void Problem<dim, PotentialType>::partial_run(const double &blessed_energy)
       << energy
       << " eV."
       << std::endl;
-
 
   const unsigned int total_n_neighbors =
     dealii::Utilities::MPI::sum(QC<dim, PotentialType>::neighbor_lists.size(),

--- a/tests/core/energy_coul_wolf_04.cc
+++ b/tests/core/energy_coul_wolf_04.cc
@@ -58,6 +58,10 @@ Problem<dim, PotentialType>::Problem (const ConfigureQC &config)
 template <int dim, typename PotentialType>
 void Problem<dim, PotentialType>::partial_run(const double &blessed_energy)
 {
+  QC<dim, PotentialType>::setup_energy_atoms_with_cluster_weights();
+  QC<dim, PotentialType>::setup_system();
+  QC<dim, PotentialType>::setup_fe_values_objects();
+  QC<dim, PotentialType>::update_neighbor_lists();
 
   unsigned int n_mpi_processes(dealii::Utilities::MPI::n_mpi_processes(QC<dim, PotentialType>::mpi_communicator)),
            this_mpi_process(dealii::Utilities::MPI::this_mpi_process(QC<dim, PotentialType>::mpi_communicator));
@@ -74,8 +78,6 @@ void Problem<dim, PotentialType>::partial_run(const double &blessed_energy)
       MPI_Barrier(QC<dim, PotentialType>::mpi_communicator);
     }
 
-  QC<dim, PotentialType>::setup_fe_values_objects();
-  QC<dim, PotentialType>::update_neighbor_lists();
   const double energy = QC<dim, PotentialType>::template
                         calculate_energy_gradient<false> (QC<dim, PotentialType>::gradient);
 


### PR DESCRIPTION
The setting up of energy atoms inside the QC constructor was moved to `run()` function in #104. Fixing `tests/core/energy_*` in this regard.