### PR TITLE
fix atom_handler_thrown_atoms tests

### DIFF
--- a/tests/atom/atom_handler_thrown_atoms_01.cc
+++ b/tests/atom/atom_handler_thrown_atoms_01.cc
@@ -6,7 +6,7 @@
 #include <deal.II/grid/grid_generator.h>
 
 #include <deal.II-qc/atom/atom_handler.h>
-#include <deal.II-qc/configure/configure_qc.h>
+#include <deal.II-qc/atom/sampling/cluster_weights_by_cell.h>
 
 using namespace dealii;
 using namespace dealiiqc;
@@ -24,6 +24,7 @@ public:
   TestAtomHandler(const ConfigureQC &config)
     :
     AtomHandler<dim>( config),
+    config(config),
     triangulation (MPI_COMM_WORLD,
                    // guarantee that the mesh also does not change by more than refinement level across vertices that might connect two cells:
                    Triangulation<dim>::limit_level_difference_at_vertices),
@@ -35,11 +36,22 @@ public:
   {
     GridGenerator::hyper_cube( triangulation, 0., 8., true );
     AtomHandler<dim>::parse_atoms_and_assign_to_cells( dof_handler, atom_data);
-    for ( const auto &entry : atom_data.n_thrown_atoms_per_cell)
+    const Cluster::WeightsByCell<dim>
+    weights_by_cell (config.get_cluster_radius(),
+                     config.get_maximum_cutoff_radius());
+    atom_data.energy_atoms =
+      weights_by_cell.update_cluster_weights (dof_handler,
+                                              atom_data.atoms);
+
+    for (auto
+         entry  = atom_data.energy_atoms.begin();
+         entry != atom_data.energy_atoms.end();
+         entry  = atom_data.energy_atoms.upper_bound(entry->first))
       std::cout << "Cell: "
-                << entry.first
+                << entry->first
                 << " has "
-                << entry.second
+                << atom_data.atoms.count(entry->first) -
+                   atom_data.energy_atoms.count(entry->first)
                 << " thrown atoms."
                 << std::endl;
 
@@ -49,6 +61,7 @@ public:
   }
 
 private:
+  const ConfigureQC &config;
   parallel::shared::Triangulation<dim> triangulation;
   DoFHandler<dim>      dof_handler;
   MPI_Comm mpi_communicator;
@@ -67,26 +80,26 @@ int main (int argc, char **argv)
       std::ostringstream oss;
       oss << "set Dimension = 3"                              << std::endl
           << "subsection Configure atoms"                     << std::endl
-          << "  set Maximum energy radius = 1.1"              << std::endl
+          << "  set Maximum cutoff radius = 1.1"              << std::endl
           << "end"                                            << std::endl
           << "subsection Configure QC"                        << std::endl
           << "  set Ghost cell layer thickness = 1.9"         << std::endl
           << "  set Cluster radius = 1.1"                     << std::endl
           << "end"                                            << std::endl
           << "#end-of-parameter-section" << std::endl
-          << "LAMMPS Description"        << std::endl << std::endl
-          << "9 atoms"                   << std::endl << std::endl
-          << "1  atom types"             << std::endl << std::endl
-          << "Atoms #"                   << std::endl << std::endl
-          << "1 1 1 1.0 2. 2. 2."      << std::endl
-          << "2 2 1 1.0 6. 2. 2."      << std::endl
-          << "3 3 1 1.0 2. 6. 2."      << std::endl
-          << "4 4 1 1.0 2. 2. 6."      << std::endl
-          << "5 5 1 1.0 6. 6. 2."      << std::endl
-          << "6 6 1 1.0 6. 2. 6."      << std::endl
-          << "7 7 1 1.0 2. 6. 6."      << std::endl
-          << "8 8 1 1.0 6. 6. 6."      << std::endl
-          << "9 9 1 1.0 7. 7. 7.9"      << std::endl;
+          << "LAMMPS Description"        << std::endl         << std::endl
+          << "9 atoms"                   << std::endl         << std::endl
+          << "1  atom types"             << std::endl         << std::endl
+          << "Atoms #"                   << std::endl         << std::endl
+          << "1 1 1 1.0 2. 2. 2."        << std::endl
+          << "2 2 1 1.0 6. 2. 2."        << std::endl
+          << "3 3 1 1.0 2. 6. 2."        << std::endl
+          << "4 4 1 1.0 2. 2. 6."        << std::endl
+          << "5 5 1 1.0 6. 6. 2."        << std::endl
+          << "6 6 1 1.0 6. 2. 6."        << std::endl
+          << "7 7 1 1.0 2. 6. 6."        << std::endl
+          << "8 8 1 1.0 6. 6. 6."        << std::endl
+          << "9 9 1 1.0 7. 8. 7.9"       << std::endl;
 
 
       std::shared_ptr<std::istream> prm_stream =


### PR DESCRIPTION
The two tests log the number of non-energy atoms per cell. It now calculates thrown atoms per cell using `n_atoms - n_energy_atoms`.  This is done without changing the blessed file. The test `.cc` file is also updated in reference to #98.