### PR TITLE
query git info and store for output to terminal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ SET(TARGET_SRC
   source/potentials/pair_coul_wolf.cc
   source/potentials/pair_lj_cut.cc
   source/core/qc.cc
+  ${CMAKE_CURRENT_BINARY_DIR}/version.cc
   )
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
@@ -49,6 +50,11 @@ IF(NOT ${deal.II_FOUND})
 ENDIF()
 
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
+
+# Run macro to get Git info:
+DEAL_II_QUERY_GIT_INFORMATION()
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/source/version.cc.in
+               ${CMAKE_CURRENT_BINARY_DIR}/version.cc)
 
 #
 # PROJECT has to be called after DEAL_II_INITIALIZE_CACHED_VARIABLES

--- a/include/deal.II-qc/version.h
+++ b/include/deal.II-qc/version.h
@@ -1,0 +1,14 @@
+#ifndef __dealii_qc_version_h
+#define __dealii_qc_version_h
+
+#include <string>
+
+namespace dealiiqc
+{
+  extern const std::string GIT_REVISION;
+  extern const std::string GIT_BRANCH;
+  extern const std::string GIT_SHORTREV;
+  extern const std::string GIT_TAG;
+}
+
+#endif

--- a/source/main.cc
+++ b/source/main.cc
@@ -7,6 +7,7 @@
 #include <deal.II/base/parameter_handler.h>
 
 #include <deal.II-qc/core/qc.h>
+#include <deal.II-qc/version.h>
 
 int main (int argc, char *argv[])
 {

--- a/source/version.cc.in
+++ b/source/version.cc.in
@@ -1,0 +1,9 @@
+#include <deal.II-qc/version.h>
+
+namespace dealiiqc
+{
+  const std::string GIT_REVISION ("@GIT_REVISION@");
+  const std::string GIT_BRANCH ("@GIT_BRANCH@");
+  const std::string GIT_SHORTREV("@GIT_SHORTREV@");
+  const std::string GIT_TAG("@GIT_TAG@");
+}


### PR DESCRIPTION
fixes https://github.com/davydden/deal.ii-qc/issues/93

version variables are defined in `.cc` so that `make` won't recompile the whole thing each and every time `cmake` is run.