### PR TITLE
Fixing the most depressing bug

### DIFF
--- a/source/atom/sampling/cluster_weights_by_cell.cc
+++ b/source/atom/sampling/cluster_weights_by_cell.cc
@@ -108,9 +108,9 @@ namespace dealiiqc
           // The cluster weight was previously set to 1. if the atom is
           // cluster atom and 0. if the atom is not cluster atom.
           energy_atom.second.cluster_weight *=
-            n_atoms_per_cell.at(energy_atom.first)
+            static_cast<double>(n_atoms_per_cell.at(energy_atom.first))
             /
-            n_cluster_atoms_per_cell.at(energy_atom.first);
+            static_cast<double>(n_cluster_atoms_per_cell.at(energy_atom.first));
         }
 
       return energy_atoms;

--- a/source/atom/sampling/cluster_weights_by_vertex.cc
+++ b/source/atom/sampling/cluster_weights_by_vertex.cc
@@ -140,9 +140,9 @@ namespace dealiiqc
           // The cluster weight was previously set to 1. if the atom is
           // cluster atom and 0. if the atom is not cluster atom.
           atom.cluster_weight *=
-            n_atoms_per_vertex[global_vertex_index]
+            static_cast<double>(n_atoms_per_vertex[global_vertex_index])
             /
-            n_cluster_atoms_per_vertex[global_vertex_index];
+            static_cast<double>(n_cluster_atoms_per_vertex[global_vertex_index]);
         }
 
       return energy_atoms;


### PR DESCRIPTION
Too bad that this was the cause of spikes in relative error in energy. 

A two-minute silence. :no_mouth: 