### PR TITLE
molecule local_index within its owned cell

### DIFF
--- a/include/deal.II-qc/atom/molecule.h
+++ b/include/deal.II-qc/atom/molecule.h
@@ -29,6 +29,17 @@ namespace dealiiqc
     std::array<Atom<spacedim>, atomicity> atoms;
 
     /**
+     * Local index of the molecule within the cell it is associated to.
+     *
+     * @note During constructing FEValues object for the cell associated to this
+     * molecule, the local_index of this molecule can be used as the index for
+     * the quadrature point corresponding to this molecule. It is convenient to
+     * have the index of the quadrature point while calling the value function
+     * of the FEValues object.
+     */
+    unsigned int local_index;
+
+    /**
      * Position of the molecule in reference coordinates of the cell to which
      * it is associated to.
      */


### PR DESCRIPTION
I had tried to refactor the code using `Molecule<dim,1>`; and it turns out that even though we don't actually need `local_index`, it is convenient to have it. Deducing it from the multimap iterator is costly each time we need it, so it has to be stored somewhere.