### PR TITLE
fix neighbor lists: distance between molecules is checked.

### DIFF
--- a/include/deal.II-qc/atom/molecule.h
+++ b/include/deal.II-qc/atom/molecule.h
@@ -18,6 +18,11 @@ namespace dealiiqc
   {
 
     /**
+     * Molecule's global index in the atomistic system.
+     */
+    types::global_molecule_index global_index;
+
+    /**
      * A list of atoms that constitute this molecule. The size of the list is
      * equal to the atomicity of the molecule. Each atom in the molecule
      * is given a different stamp and therefore the order of atoms is important
@@ -57,7 +62,7 @@ namespace dealiiqc
 
 
 
-  // TODO: Move this function to a different place?
+  // TODO: Move the following functions to a different place?
   /**
    * Return the initial location of @p molecule. The initial location is
    * nothing but its location in the Lagrangian (undeformed) configuration of
@@ -82,6 +87,33 @@ namespace dealiiqc
 #endif
 
     return molecule.atoms[0].initial_position;
+  }
+
+
+
+  /**
+   * Return the least distance squared between atoms of @p molecule_A and
+   * @p molecule_B.
+   */
+  template<int spacedim, int atomicity>
+  inline
+  double
+  least_distance_squared (const Molecule<spacedim, atomicity> &molecule_A,
+                          const Molecule<spacedim, atomicity> &molecule_B)
+  {
+    double squared_distance = std::numeric_limits<double>::max();
+
+    for (const auto &atom_A : molecule_A.atoms)
+      for (const auto &atom_B : molecule_B.atoms)
+        {
+          const double tmp_squared_distance =
+            atom_A.position.distance_square(atom_B.position);
+
+          if (tmp_squared_distance < squared_distance)
+            squared_distance = tmp_squared_distance;
+        }
+
+    return squared_distance;
   }
 
 

--- a/include/deal.II-qc/utilities.h
+++ b/include/deal.II-qc/utilities.h
@@ -56,6 +56,7 @@
 
 namespace dealiiqc
 {
+
   /**
    * Custom types used inside dealiiqc.
    */
@@ -68,6 +69,11 @@ namespace dealiiqc
      * The data type always indicates an unsigned integer type.
      */
     typedef  dealii::types::global_dof_index global_atom_index;
+
+    /**
+     * The type used for global indices of molecules.
+     */
+    typedef  global_atom_index global_molecule_index;
 
     // TODO: Use of correct charge units; Use charge_t for book keeping.
     /**
@@ -146,8 +152,9 @@ namespace dealiiqc
     {
       // Throw exception if the given cell is is not in a valid
       // cell iterator state.
-      AssertThrow( cell->state() == IteratorState::valid,
-                   ExcMessage( "The given cell iterator is not in a valid iterator state"));
+      AssertThrow (cell->state() == IteratorState::valid,
+                   ExcMessage ("The given cell iterator is not in a "
+                               "valid iterator state"));
 
       // Assume the first vertex is the closest at first.
       double squared_distance = p.distance_square(cell->vertex(0));
@@ -169,8 +176,8 @@ namespace dealiiqc
 
 
     /**
-     * Utility function that returns true if a point @p p is outside a bounding box.
-     * The box is specified by two points @p minp and @p maxp (the order of
+     * Utility function that returns true if a point @p p is outside a bounding
+     * box. The box is specified by two points @p minp and @p maxp (the order of
      * specifying points is important).
      */
     template<int dim>
@@ -199,17 +206,20 @@ namespace dealiiqc
      * The input string can end without specifying any delimiters (possibly
      * followed by an arbitrary amount of whitespace). For example,
      * @code
-     *   Utilities::split_list_of_string_lists("abc, def; ghi; j, k, l; ", ';', ',');
+     *   Utilities::split_list_of_string_lists
+     *   ("abc, def; ghi; j, k, l; ", ';', ',');
      * @endcode
      * yields the same 3-element list of sub-lists output
      * <code>{ {"abc", "def"},{"ghi"}, {"j", "k", "l"}}</code>
      * as you would get if the input had been
      * @code
-     *   Utilities::split_list_of_string_lists("abc, def; ghi; j, k, l", ';', ',');
+     *   Utilities::split_list_of_string_lists
+     *   ("abc, def; ghi; j, k, l", ';', ',');
      * @endcode
      * or
      * @code
-     *   Utilities::split_list_of_string_lists("abc, def; ghi; j, k, l;", ';', ',');
+     *   Utilities::split_list_of_string_lists
+     *   ("abc, def; ghi; j, k, l;", ';', ',');
      * @endcode
      */
     inline

--- a/source/atom/molecule_handler.cc
+++ b/source/atom/molecule_handler.cc
@@ -4,10 +4,8 @@
 #include <deal.II-qc/atom/molecule_handler.h>
 
 
-
 namespace dealiiqc
 {
-
 
 
   template<int dim, int atomicity, int spacedim>
@@ -15,41 +13,46 @@ namespace dealiiqc
   MoleculeHandler (const ConfigureQC &configure_qc)
     :
     configure_qc(configure_qc)
-  {
-  }
+  {}
 
 
 
   template<int dim, int atomicity, int spacedim>
   types::CellMoleculeNeighborLists<dim, atomicity, spacedim>
   MoleculeHandler<dim, atomicity, spacedim>::
-  get_neighbor_lists (const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules) const
+  get_neighbor_lists
+  (const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules) const
   {
-    // Check to see if energy_atoms is updated.
+    // Check whether cell_energy_molecules is empty; throw error if it is.
     Assert (cell_energy_molecules.size(),
             ExcInternalError());
 
     types::CellMoleculeNeighborLists<dim, atomicity, spacedim> neighbor_lists;
 
     // cell_neighbor_lists contains all the pairs of cell
-    // whose atoms interact with each other.
-    std::list< std::pair< types::CellIteratorType<dim, spacedim>, types::CellIteratorType<dim, spacedim>>> cell_neighbor_lists;
+    // whose molecules interact with each other.
+    std::list< std::pair<
+    types::CellIteratorType<dim, spacedim>
+    ,
+    types::CellIteratorType<dim, spacedim> >> cell_neighbor_lists;
 
     const double cutoff_radius  = configure_qc.get_maximum_cutoff_radius();
-    const double squared_cutoff_radius  = dealii::Utilities::fixed_power<2>(cutoff_radius);
+    const double squared_cutoff_radius  =
+      dealii::Utilities::fixed_power<2>(cutoff_radius);
 
     // For each locally owned cell, identify all the cells
-    // whose associated atoms may interact.At this point we do not
-    // check if there are indeed some interacting atoms,
+    // whose associated molecules may interact. At this point we do not
+    // check if there are indeed some interacting molecules,
     // i.e. those within the cut-off radius. This is done to speedup
     // building of the neighbor list.
     // TODO: this approach strictly holds in the reference
     // (undeformed) configuration only.
-    // It may still be ok for small deformations,
+    // It may still be OK for small deformations,
     // but for large deformations we may need to
     // use something like MappingQEulerian to work
     // with the deformed mesh.
-    // TODO: optimize loop over unique keys ( mulitmap::upper_bound()'s complexity is O(nlogn) )
+    // TODO: optimize loop over unique keys
+    // ( mulitmap::upper_bound()'s complexity is O(nlogn) )
     for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
          unique_I  = cell_energy_molecules.cbegin();
          unique_I != cell_energy_molecules.cend();
@@ -67,7 +70,8 @@ namespace dealiiqc
                unique_J != cell_energy_molecules.cend();
                unique_J  = cell_energy_molecules.upper_bound(unique_J->first))
             {
-              types::ConstCellIteratorType<dim, spacedim> cell_J = unique_J->first;
+              types::ConstCellIteratorType<dim, spacedim>
+              cell_J = unique_J->first;
 
               // Get center and the radius of the enclosing ball of cell_I
               const auto enclosing_ball_J = cell_J->enclosing_ball();
@@ -83,7 +87,7 @@ namespace dealiiqc
             }
         }
 
-    for (const auto cell_pair_IJ : cell_neighbor_lists )
+    for (const auto &cell_pair_IJ : cell_neighbor_lists)
       {
         types::ConstCellIteratorType<dim, spacedim> cell_I = cell_pair_IJ.first;
         types::ConstCellIteratorType<dim, spacedim> cell_J = cell_pair_IJ.second;
@@ -96,47 +100,61 @@ namespace dealiiqc
         range_of_cell_I = cell_energy_molecules.equal_range(cell_I),
         range_of_cell_J = cell_energy_molecules.equal_range(cell_J);
 
-        // for each atom associated to locally owned cell_I
+        // For each molecule associated to locally owned cell_I
         for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
              cell_molecule_I  = range_of_cell_I.first;
              cell_molecule_I != range_of_cell_I.second;
              cell_molecule_I++)
           {
-            // FIXME: Check distances between all atoms of one molecule to
-            //        all atoms of the other molecule. If any two atoms of
-            //        different molecules interact, then the molecules are in
-            //        neighbor lists.
-            const Atom<spacedim> &atom_I = cell_molecule_I->second.atoms[0];
 
-            // Check if the atom_I is cluster atom,
-            // only cluster atoms get to have neighbor lists
-            if (cell_molecule_I->second.cluster_weight != 0)
+            const Molecule<spacedim, atomicity>
+            &molecule_I = cell_molecule_I->second;
+
+            // Check if the molecule_I is cluster molecule,
+            // only cluster molecules get to be in neighbor lists.
+            if (molecule_I.cluster_weight != 0)
+
               for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
                    cell_molecule_J  = range_of_cell_J.first;
                    cell_molecule_J != range_of_cell_J.second;
                    cell_molecule_J++ )
                 {
-                  // FIXME: Check for all atoms in molecule.
-                  const Atom<spacedim> &atom_J = cell_molecule_J->second.atoms[0];
 
-                  const bool atom_J_is_cluster_atom =
-                    cell_molecule_J->second.cluster_weight != 0;
+                  const Molecule<spacedim, atomicity>
+                  &molecule_J = cell_molecule_J->second;
 
-                  // If atom_J is not cluster atom,
-                  // then add atom_J to (cluster) atom_I's neighbor list.
+                  // Check whether molecule_J is cluster molecule
+                  const bool
+                  molecule_J_is_cluster_molecule =
+                      (molecule_J.cluster_weight != 0);
 
-                  // If atom_J is also a cluster atom,
-                  // then atom_J is only added to atom_I's neighbor list
-                  // when atom_I's index is smaller. This ensures
-                  // that there is no double counting of energy
-                  // contribution due to cluster atoms - atom_I and atom_J
-
-                  if ( (atom_J_is_cluster_atom &&
-                        (atom_I.global_index > atom_J.global_index))
+                  // If molecule_J is also a cluster molecule,
+                  // then molecule_J could be only added to molecule_I's neighbor
+                  // list when molecule_I's index is greater than that of
+                  // molecule_J. This ensures that there is no double counting of
+                  // energy contribution thorugh both the cluster molecules:
+                  // molecule_I and molecule_J.
+                  // OR
+                  // If molecule_J is not cluster molecule,
+                  // then molecule_J could be added to (cluster) molecule_I's
+                  // neighbor list.
+                  if ( (molecule_J_is_cluster_molecule &&
+                        (molecule_I.global_index > molecule_J.global_index))
                        ||
-                       !atom_J_is_cluster_atom )
-                    if (atom_I.position.distance_square(atom_J.position) < squared_cutoff_radius)
-                      neighbor_lists.insert( std::make_pair( cell_pair_IJ, std::make_pair( cell_molecule_I, cell_molecule_J)) );
+                       !molecule_J_is_cluster_molecule )
+
+                    // Check distances between all atoms of one molecule to
+                    // all atoms of the other molecule. If any two atoms of
+                    // different molecules interact, then the molecules are in
+                    // neighbor lists.
+                    if (least_distance_squared(molecule_I, molecule_J)
+                        < squared_cutoff_radius)
+                      neighbor_lists.insert
+                      (
+                        std::make_pair (cell_pair_IJ,
+                                        std::make_pair (cell_molecule_I,
+                                                        cell_molecule_J))
+                      );
                 }
           }
 
@@ -157,33 +175,37 @@ namespace dealiiqc
     //     loop over all atoms
     //       if within distance
     //         total_number_of_interactions++;
-    for (auto cell_molecule_I : cell_energy_molecules)
+    for (const auto &cell_molecule_I : cell_energy_molecules)
       if (cell_molecule_I.first->is_locally_owned())
         {
-          // FIXME: here (loop over atoms in molecule)
-          const Atom<spacedim> &atom_I = cell_molecule_I.second.atoms[0];
+          const Molecule<spacedim, atomicity>
+          &molecule_I = cell_molecule_I.second;
 
-          // We are building neighbor lists for only atom_Is
-          // so we can skip atom_I if it's not a cluster atom.
-          if (cell_molecule_I.second.cluster_weight != 0)
-            for (auto cell_molecule_J : cell_energy_molecules)
+          // Check if the molecule_I is cluster molecule,
+          // only cluster molecules get to be in neighbor lists.
+          if (molecule_I.cluster_weight != 0)
+            for (const auto &cell_molecule_J : cell_energy_molecules)
               {
-                // FIXME: here (loop over atoms in molecule)
-                const Atom<spacedim> &atom_J = cell_molecule_J.second.atoms[0];
+                const Molecule<spacedim, atomicity>
+                &molecule_J = cell_molecule_J.second;
 
-                const bool atom_J_is_cluster_atom =
-                  cell_molecule_J.second.cluster_weight != 0;
+                // Check whether molecule_J is cluster molecule
+                const bool
+                molecule_J_is_cluster_molecule =
+                    (molecule_J.cluster_weight != 0);
 
-                if ( (atom_J_is_cluster_atom &&
-                      (atom_I.global_index > atom_J.global_index))
+                if ( (molecule_J_is_cluster_molecule &&
+                      (molecule_I.global_index > molecule_J.global_index))
                      ||
-                     !atom_J_is_cluster_atom )
-                  if (atom_I.position.distance_square(atom_J.position) < squared_cutoff_radius)
+                     !molecule_J_is_cluster_molecule )
+                  if (least_distance_squared(molecule_I, molecule_J)
+                      < squared_cutoff_radius)
                     total_number_of_interactions++;
               }
         }
     Assert (total_number_of_interactions == neighbor_lists.size(),
-            ExcMessage("Some of the interactions are not accounted while updating neighbor lists"));
+            ExcMessage("Some of the interactions are not accounted "
+                       "while updating neighbor lists"));
 #endif
 
     return neighbor_lists;

--- a/source/atom/parse_atom_data.cc
+++ b/source/atom/parse_atom_data.cc
@@ -262,6 +262,9 @@ namespace dealiiqc
 
         i_molecule = static_cast<types::global_atom_index>(i_molecule_index) - 1;
 
+        // Set molecule global id
+        molecules[i_molecule].global_index = i_molecule;
+
         // Add atom to the molecule.
         molecules[i_molecule].atoms[n_atoms_added_per_molecule[i_molecule]] =
           temporary_atom;


### PR DESCRIPTION
- added new function that computes the minimum distance between atoms of two molecules.
- added unique identifier(global_index) for molecules (the input atom data also has it)
- build neighbor lists for molecules (accounting for both inter and intra-molecular interactions)

The blessed output is changed since we also need to account for intra-molecular interactions. Earlier atom wouldn't interact with itself but now a molecule could interaction with itself (or a molecule's constituents can interact with its other constituents).