### PR TITLE
DEAL_II_QC_NAMESPACE_OPEN and CLOSE

### DIFF
--- a/include/deal.II-qc/atom/atom.h
+++ b/include/deal.II-qc/atom/atom.h
@@ -5,48 +5,50 @@
 
 #include <deal.II-qc/utilities.h>
 
-namespace dealiiqc
+
+DEAL_II_QC_NAMESPACE_OPEN
+
+
+using namespace dealii;
+
+/**
+ * A class for atoms embedded in a <tt>spacedim</tt>-dimensional space.
+ *
+ * This class does not contain some more atom attributes such as charge and
+ * mass etc. This is because the number of different atom types in an
+ * atomistic system is far less than the number of atoms. The charges and
+ * masses of different atom types can be stored elsewhere in a central pool.
+ *
+ * A drude particles can be constructed using two Atom objects. One object for
+ * the charged core and another for the charged shell.
+ */
+template <int spacedim>
+struct Atom
 {
-  using namespace dealii;
 
   /**
-   * A class for atoms embedded in a <tt>spacedim</tt>-dimensional space.
-   *
-   * This class does not contain some more atom attributes such as charge and
-   * mass etc. This is because the number of different atom types in an
-   * atomistic system is far less than the number of atoms. The charges and
-   * masses of different atom types can be stored elsewhere in a central pool.
-   *
-   * A drude particles can be constructed using two Atom objects. One object for
-   * the charged core and another for the charged shell.
+   * Global atom index of this atom.
    */
-  template <int spacedim>
-  struct Atom
-  {
+  types::global_atom_index global_index;
 
-    /**
-     * Global atom index of this atom.
-     */
-    types::global_atom_index global_index;
+  /**
+   * Atom species type.
+   */
+  types::atom_type type;
 
-    /**
-     * Atom species type.
-     */
-    types::atom_type type;
+  /**
+   * Initial position of the atom in <tt>spacedim</tt>-dimensional space.
+   */
+  Point<spacedim> initial_position;
 
-    /**
-     * Initial position of the atom in <tt>spacedim</tt>-dimensional space.
-     */
-    Point<spacedim> initial_position;
+  /**
+   * Current position of the atom in <tt>spacedim</tt>-dimensional space.
+   */
+  Point<spacedim> position;
 
-    /**
-     * Current position of the atom in <tt>spacedim</tt>-dimensional space.
-     */
-    Point<spacedim> position;
-
-  };
+};
 
 
-} // namespace dealiiqc
+DEAL_II_QC_NAMESPACE_CLOSE
 
 #endif // __dealii_qc_atom_h

--- a/include/deal.II-qc/atom/cell_molecule_data.h
+++ b/include/deal.II-qc/atom/cell_molecule_data.h
@@ -3,133 +3,134 @@
 
 #include <deal.II-qc/atom/molecule.h>
 
-namespace dealiiqc
+
+DEAL_II_QC_NAMESPACE_OPEN
+
+
+namespace types
 {
 
-  namespace types
-  {
-
-    /**
-     * A typedef for a pair of cell and molecule.
-     */
-    template<int dim, int atomicity=1, int spacedim=dim>
-    using CellMolecule =
-      typename
-      std::pair<CellIteratorType<dim, spacedim>, Molecule<spacedim, atomicity>>;
-
-    /**
-     * A typedef for a const pair of cell and molecule.
-     */
-    template<int dim, int atomicity=1, int spacedim=dim>
-    using ConstCellMolecule =
-      const typename
-      std::pair<CellIteratorType<dim, spacedim>, Molecule<spacedim, atomicity>>;
-
-    /**
-     * A typedef for container that holds cell and associated molecules.
-     */
-    template<int dim, int atomicity=1, int spacedim=dim>
-    using CellMoleculeContainerType =
-      typename std::multimap<CellIteratorType<dim, spacedim>, Molecule<spacedim, atomicity>>;
-
-    /**
-     * A typedef for iterator over CellMoleculeContainerType.
-     */
-    template<int dim, int atomicity=1, int spacedim=dim>
-    using CellMoleculeIteratorType =
-      typename CellMoleculeContainerType<dim, atomicity, spacedim>::iterator;
-
-    /**
-     * A typedef for const_iterator over CellMoleculeContainerType.
-     */
-    template<int dim, int atomicity=1, int spacedim=dim>
-    using CellMoleculeConstIteratorType =
-      typename CellMoleculeContainerType<dim, atomicity, spacedim>::const_iterator;
-
-    /**
-     * A typedef for a pair of const_iterators over CellMoleculeContainerType
-     * which could be used in the case of storing a iterator range.
-     */
-    template<int dim, int atomicity=1, int spacedim=dim>
-    using CellMoleculeConstIteratorRangeType =
-      typename
-      std::pair
-      <
-      CellMoleculeConstIteratorType<dim, atomicity, spacedim>,
-      CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-      >;
-
-    /**
-     * A typedef for neighbor lists, a multimap of a pair of cells and a pair of
-     * molecules in a cell based data structure.
-     */
-    template<int dim, int atomicity=1, int spacedim=dim>
-    using CellMoleculeNeighborLists =
-      typename std::multimap <
-      std::pair
-      <
-      ConstCellIteratorType<dim, spacedim>,
-      ConstCellIteratorType<dim, spacedim>
-      >,
-      std::pair
-      <
-      CellMoleculeConstIteratorType<dim, atomicity, spacedim>,
-      CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-      >>;
-
-
-  } // types
-
-
-
   /**
-   * A principal class that holds cell based molecule data structures with the
-   * association between molecules and mesh.
-   *
-   * The association between molecules and cells allows for accessing each
-   * molecule through its associated cell. The cell based molecule data
-   * structures in this class can be initialized using MoleculeHandler
-   * class member functions.
+   * A typedef for a pair of cell and molecule.
    */
   template<int dim, int atomicity=1, int spacedim=dim>
-  struct CellMoleculeData
-  {
+  using CellMolecule =
+    typename
+    std::pair<CellIteratorType<dim, spacedim>, Molecule<spacedim, atomicity>>;
 
-    /**
-     * A vector of charges of different atom species.
-     */
-    std::shared_ptr<std::vector<types::charge>> charges;
+  /**
+   * A typedef for a const pair of cell and molecule.
+   */
+  template<int dim, int atomicity=1, int spacedim=dim>
+  using ConstCellMolecule =
+    const typename
+    std::pair<CellIteratorType<dim, spacedim>, Molecule<spacedim, atomicity>>;
 
-    /**
-     * A vector to store masses of different atom species.
-     */
-    std::vector<double> masses;
+  /**
+   * A typedef for container that holds cell and associated molecules.
+   */
+  template<int dim, int atomicity=1, int spacedim=dim>
+  using CellMoleculeContainerType =
+    typename std::multimap<CellIteratorType<dim, spacedim>, Molecule<spacedim, atomicity>>;
 
-    /**
-     * The cell based data member that contains cells and molecules
-     * association in the Lagrangian (undeformed) configuration of the system.
-     * More specifically, #cell_molecules contains association between locally
-     * relevant cells and locally relevant molecules in the Lagrangian
-     * (undeformed) configuration of the system.
-     */
-    types::CellMoleculeContainerType<dim, atomicity, spacedim> cell_molecules;
+  /**
+   * A typedef for iterator over CellMoleculeContainerType.
+   */
+  template<int dim, int atomicity=1, int spacedim=dim>
+  using CellMoleculeIteratorType =
+    typename CellMoleculeContainerType<dim, atomicity, spacedim>::iterator;
 
-    /**
-     * The cell based data member that contains cells and energy molecules
-     * association of the system.
-     *
-     * This data member contains energy molecules with the current atoms'
-     * positions. This information is the central information for
-     * energy and force computations. Each MPI process would then be
-     * responsible to compute energy and forces only of its locally owned
-     * sampling (or cluster) molecules.
-     */
-    types::CellMoleculeContainerType<dim, atomicity, spacedim> cell_energy_molecules;
+  /**
+   * A typedef for const_iterator over CellMoleculeContainerType.
+   */
+  template<int dim, int atomicity=1, int spacedim=dim>
+  using CellMoleculeConstIteratorType =
+    typename CellMoleculeContainerType<dim, atomicity, spacedim>::const_iterator;
 
-  };
+  /**
+   * A typedef for a pair of const_iterators over CellMoleculeContainerType
+   * which could be used in the case of storing a iterator range.
+   */
+  template<int dim, int atomicity=1, int spacedim=dim>
+  using CellMoleculeConstIteratorRangeType =
+    typename
+    std::pair
+    <
+    CellMoleculeConstIteratorType<dim, atomicity, spacedim>,
+    CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+    >;
+
+  /**
+   * A typedef for neighbor lists, a multimap of a pair of cells and a pair of
+   * molecules in a cell based data structure.
+   */
+  template<int dim, int atomicity=1, int spacedim=dim>
+  using CellMoleculeNeighborLists =
+    typename std::multimap <
+    std::pair
+    <
+    ConstCellIteratorType<dim, spacedim>,
+    ConstCellIteratorType<dim, spacedim>
+    >,
+    std::pair
+    <
+    CellMoleculeConstIteratorType<dim, atomicity, spacedim>,
+    CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+    >>;
 
 
-} // namespace dealiiqc
+} // types
+
+
+
+/**
+ * A principal class that holds cell based molecule data structures with the
+ * association between molecules and mesh.
+ *
+ * The association between molecules and cells allows for accessing each
+ * molecule through its associated cell. The cell based molecule data
+ * structures in this class can be initialized using MoleculeHandler
+ * class member functions.
+ */
+template<int dim, int atomicity=1, int spacedim=dim>
+struct CellMoleculeData
+{
+
+  /**
+   * A vector of charges of different atom species.
+   */
+  std::shared_ptr<std::vector<types::charge>> charges;
+
+  /**
+   * A vector to store masses of different atom species.
+   */
+  std::vector<double> masses;
+
+  /**
+   * The cell based data member that contains cells and molecules
+   * association in the Lagrangian (undeformed) configuration of the system.
+   * More specifically, #cell_molecules contains association between locally
+   * relevant cells and locally relevant molecules in the Lagrangian
+   * (undeformed) configuration of the system.
+   */
+  types::CellMoleculeContainerType<dim, atomicity, spacedim> cell_molecules;
+
+  /**
+   * The cell based data member that contains cells and energy molecules
+   * association of the system.
+   *
+   * This data member contains energy molecules with the current atoms'
+   * positions. This information is the central information for
+   * energy and force computations. Each MPI process would then be
+   * responsible to compute energy and forces only of its locally owned
+   * sampling (or cluster) molecules.
+   */
+  types::CellMoleculeContainerType<dim, atomicity, spacedim> cell_energy_molecules;
+
+};
+
+
+DEAL_II_QC_NAMESPACE_CLOSE
 
 
 #endif // __dealii_qc_cell_molecule_data_h

--- a/include/deal.II-qc/atom/cell_molecule_tools.h
+++ b/include/deal.II-qc/atom/cell_molecule_tools.h
@@ -6,103 +6,104 @@
 #include<deal.II-qc/atom/cell_molecule_data.h>
 
 
-namespace dealiiqc
+DEAL_II_QC_NAMESPACE_OPEN
+
+
+/**
+ * A namespace for cell based data structures' utility functions.
+ */
+namespace CellMoleculeTools
 {
 
   /**
-   * A namespace for cell based data structures' utility functions.
+   * Return a pair of range of constant iterators to CellMoleculeContainerType
+   * object of atoms @p cell_molecules and the number of atoms of @p atoms in
+   * a given @p cell.
+   *
+   * If no molecules are in the queried cell then the function return the
+   * pair of (pair of) end iterators and zero. If @p cell_molecules is an
+   * empty CellMoleculeContainer, then the function throws an error that
+   * the provided CellMoleculeContainer is empty.
    */
-  namespace CellMoleculeTools
-  {
+  template<int dim, int atomicity=1, int spacedim=dim>
+  std::pair
+  <
+  types::CellMoleculeConstIteratorRangeType<dim, atomicity, spacedim>
+  ,
+  unsigned int
+  >
+  molecules_range_in_cell
+  (const types::CellIteratorType<dim, spacedim>                     &cell,
+   const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules);
 
-    /**
-     * Return a pair of range of constant iterators to CellMoleculeContainerType
-     * object of atoms @p cell_molecules and the number of atoms of @p atoms in
-     * a given @p cell.
-     *
-     * If no molecules are in the queried cell then the function return the
-     * pair of (pair of) end iterators and zero. If @p cell_molecules is an
-     * empty CellMoleculeContainer, then the function throws an error that
-     * the provided CellMoleculeContainer is empty.
-     */
-    template<int dim, int atomicity=1, int spacedim=dim>
-    std::pair
-    <
-    types::CellMoleculeConstIteratorRangeType<dim, atomicity, spacedim>
-    ,
-    unsigned int
-    >
-    molecules_range_in_cell
-    (const types::CellIteratorType<dim, spacedim>                     &cell,
-     const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules);
+  /**
+   * Return the number of molecules in @p cell_energy_molecules, associated to
+   * @p cell, which have non-zero cluster weights.
+   */
+  template<int dim, int atomicity=1, int spacedim=dim>
+  unsigned int
+  n_cluster_molecules_in_cell
+  (const types::CellIteratorType<dim, spacedim>                     &cell,
+   const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules);
 
-    /**
-     * Return the number of molecules in @p cell_energy_molecules, associated to @p cell,
-     * which have non-zero cluster weights.
-     */
-    template<int dim, int atomicity=1, int spacedim=dim>
-    unsigned int
-    n_cluster_molecules_in_cell
-    (const types::CellIteratorType<dim, spacedim>                     &cell,
-     const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules);
+  /**
+   * Prepare and return a CellMoleculeData object based on the given @p mesh
+   * by parsing the atom data information in @p is using a
+   * @p ghost_cell_layer_thickness distance to identify locally relevant
+   * cells for each MPI process. All the data members of the returned object
+   * are initialized except CellMoleculeData::cell_energy_molecules, which
+   * can be obtained using MoleculeHandler::get_cell_energy_molecules().
+   *
+   * <h5>Association between locally relevant cells and molecules</h5>
+   *
+   * For each MPI process, locally relevant cells (see MoleculeHandler) are
+   * identified using a distance of @p ghost_cell_layer_thickness from the
+   * locally owned cells of the MPI process.
+   *
+   * To associate locally relevant cells and molecules, each MPI process does
+   * the following. For each molecule in the system look for a locally
+   * relevant cell of the @p mesh which contains the molecule in the
+   * Lagrangian (undeformed) configuration (also referred to as the molecule's
+   * initial location which can be obtained from the
+   * molecule_initial_location() helper function). If such a cell is found
+   * which is locally relevant from the perspective of the current MPI
+   * process, the molecule is locally relevant and is associated to the
+   * cell and kept by the current MPI process. Otherwise the current MPI
+   * process disregards the molecule as it should be picked up by another
+   * MPI process.
+   *
+   * The following optimization technique is employed while associating
+   * molecules to cells.
+   * For each molecule in the system, before going over all locally relevant
+   * cells to find if the molecule's location lies within it, we can first
+   * check whether the molecule's location lies inside the bounding box of
+   * the current processor's set of locally relevant cells.
+   */
+  template<int dim, int atomicity=1, int spacedim=dim>
+  CellMoleculeData<dim, atomicity, spacedim>
+  build_cell_molecule_data (std::istream                         &is,
+                            const types::MeshType<dim, spacedim> &mesh,
+                            double          ghost_cell_layer_thickness);
 
-    /**
-     * Prepare and return a CellMoleculeData object based on the given @p mesh
-     * by parsing the atom data information in @p is using a
-     * @p ghost_cell_layer_thickness distance to identify locally relevant
-     * cells for each MPI process. All the data members of the returned object
-     * are initialized except CellMoleculeData::cell_energy_molecules, which
-     * can be obtained using MoleculeHandler::get_cell_energy_molecules().
-     *
-     * <h5>Association between locally relevant cells and molecules</h5>
-     *
-     * For each MPI process, locally relevant cells (see MoleculeHandler) are
-     * identified using a distance of @p ghost_cell_layer_thickness from the
-     * locally owned cells of the MPI process.
-     *
-     * To associate locally relevant cells and molecules, each MPI process does
-     * the following. For each molecule in the system look for a locally
-     * relevant cell of the @p mesh which contains the molecule in the
-     * Lagrangian (undeformed) configuration (also referred to as the molecule's
-     * initial location which can be obtained from the
-     * molecule_initial_location() helper function). If such a cell is found
-     * which is locally relevant from the perspective of the current MPI
-     * process, the molecule is locally relevant and is associated to the
-     * cell and kept by the current MPI process. Otherwise the current MPI
-     * process disregards the molecule as it should be picked up by another
-     * MPI process.
-     *
-     * The following optimization technique is employed while associating
-     * molecules to cells.
-     * For each molecule in the system, before going over all locally relevant
-     * cells to find if the molecule's location lies within it, we can first
-     * check whether the molecule's location lies inside the bounding box of
-     * the current processor's set of locally relevant cells.
-     */
-    template<int dim, int atomicity=1, int spacedim=dim>
-    CellMoleculeData<dim, atomicity, spacedim>
-    build_cell_molecule_data (std::istream                         &is,
-                              const types::MeshType<dim, spacedim> &mesh,
-                              double          ghost_cell_layer_thickness);
-
-    /**
-     * Return the set of global DoF indices of the locally relevant DoFs on the
-     * current MPI process. The set of locally relevant DoF indices is the union
-     * of all the DoF indices enumerated on the @ref LocallyRelevantCells
-     * "locally relevant cells" i.e., the union of
-     * DoFHandler::locally_owned_dofs() and the DoF indices on all locally
-     * relevant ghost cells.
-     */
-    template <int dim, int atomicity, int spacedim>
-    IndexSet
-    extract_locally_relevant_dofs
-    (const types::MeshType<dim, spacedim>                             &dof_handler,
-     const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules);
+  /**
+   * Return the set of global DoF indices of the locally relevant DoFs on the
+   * current MPI process. The set of locally relevant DoF indices is the union
+   * of all the DoF indices enumerated on the @ref LocallyRelevantCells
+   * "locally relevant cells" i.e., the union of
+   * DoFHandler::locally_owned_dofs() and the DoF indices on all locally
+   * relevant ghost cells.
+   */
+  template <int dim, int atomicity, int spacedim>
+  IndexSet
+  extract_locally_relevant_dofs
+  (const types::MeshType<dim, spacedim>                             &dof_handler,
+   const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules);
 
 
-  } // namespace CellMoleculeTools
+} // namespace CellMoleculeTools
 
 
-} // namespace dealiiqc
+DEAL_II_QC_NAMESPACE_CLOSE
+
 
 #endif /* __dealii_qc_atom_cell_molecule_tools_h */

--- a/include/deal.II-qc/atom/molecule.h
+++ b/include/deal.II-qc/atom/molecule.h
@@ -3,123 +3,123 @@
 
 #include <deal.II-qc/atom/atom.h>
 
-namespace dealiiqc
+
+DEAL_II_QC_NAMESPACE_OPEN
+
+
+using namespace dealii;
+
+/**
+ * A class for molecules embedded in a <tt>spacedim</tt>-dimensional space.
+ *
+ * The <tt>atomicity</tt> of a molecule, that is the number of atoms it
+ * contains, must be known at compile time.
+ */
+template<int spacedim, int atomicity=1>
+struct Molecule
 {
-  using namespace dealii;
 
   /**
-   * A class for molecules embedded in a <tt>spacedim</tt>-dimensional space.
-   *
-   * The <tt>atomicity</tt> of a molecule, that is the number of atoms it
-   * contains, must be known at compile time.
+   * Molecule's global index in the atomistic system.
    */
-  template<int spacedim, int atomicity=1>
-  struct Molecule
-  {
+  types::global_molecule_index global_index;
 
-    /**
-     * Molecule's global index in the atomistic system.
-     */
-    types::global_molecule_index global_index;
-
-    /**
-     * A list of atoms that constitute this molecule. The size of the list is
-     * equal to the atomicity of the molecule. Each atom in the molecule
-     * is given a different stamp and therefore the order of atoms is important
-     * and is according to their stamp.
-     */
-    std::array<Atom<spacedim>, atomicity> atoms;
-
-    /**
-     * Local index of the molecule within the cell it is associated to.
-     *
-     * @note During constructing FEValues object for the cell associated to this
-     * molecule, the local_index of this molecule can be used as the index for
-     * the quadrature point corresponding to this molecule. It is convenient to
-     * have the index of the quadrature point while calling the value function
-     * of the FEValues object.
-     */
-    unsigned int local_index;
-
-    /**
-     * Position of the molecule in reference coordinates of the cell to which
-     * it is associated to.
-     */
-    Point<spacedim> position_inside_reference_cell;
-
-    /**
-     * Representativeness of this molecule in its contribution to the
-     * total energy of the atomistic system.
-     *
-     * A molecule is inside a cluster if any of its atoms are geometrically
-     * inside the cluster. Any molecule that is located inside a cluster is a
-     * cluster molecule or sampling molecule. All the sampling molecules have
-     * non-zero @p cluster_weight.
-     */
-    double cluster_weight;
-
-  };
-
-
-
-  // TODO: Move the following functions to a different place?
   /**
-   * Return the initial location of @p molecule. The initial location is
-   * nothing but its location in the Lagrangian (undeformed) configuration of
-   * the atomistic system. By convention, the initial location of the molecule
-   * is the initial position of the first atom of the molecule.
-   *
-   * @note It is assumed here that the atoms of the molecule are already sorted
-   * according to their stamps.
+   * A list of atoms that constitute this molecule. The size of the list is
+   * equal to the atomicity of the molecule. Each atom in the molecule
+   * is given a different stamp and therefore the order of atoms is important
+   * and is according to their stamp.
    */
-  template<int spacedim, int atomicity>
-  inline
-  Point<spacedim> molecule_initial_location (const Molecule<spacedim, atomicity> &molecule)
-  {
-    Assert (molecule.atoms.size()>0, ExcInternalError());
+  std::array<Atom<spacedim>, atomicity> atoms;
+
+  /**
+   * Local index of the molecule within the cell it is associated to.
+   *
+   * @note During constructing FEValues object for the cell associated to this
+   * molecule, the local_index of this molecule can be used as the index for
+   * the quadrature point corresponding to this molecule. It is convenient to
+   * have the index of the quadrature point while calling the value function
+   * of the FEValues object.
+   */
+  unsigned int local_index;
+
+  /**
+   * Position of the molecule in reference coordinates of the cell to which
+   * it is associated to.
+   */
+  Point<spacedim> position_inside_reference_cell;
+
+  /**
+   * Representativeness of this molecule in its contribution to the
+   * total energy of the atomistic system.
+   *
+   * A molecule is inside a cluster if any of its atoms are geometrically
+   * inside the cluster. Any molecule that is located inside a cluster is a
+   * cluster molecule or sampling molecule. All the sampling molecules have
+   * non-zero @p cluster_weight.
+   */
+  double cluster_weight;
+
+};
+
+
+
+// TODO: Move the following functions to a different place?
+/**
+ * Return the initial location of @p molecule. The initial location is
+ * nothing but its location in the Lagrangian (undeformed) configuration of
+ * the atomistic system. By convention, the initial location of the molecule
+ * is the initial position of the first atom of the molecule.
+ *
+ * @note It is assumed here that the atoms of the molecule are already sorted
+ * according to their stamps.
+ */
+template<int spacedim, int atomicity>
+inline
+Point<spacedim> molecule_initial_location (const Molecule<spacedim, atomicity> &molecule)
+{
+  Assert (molecule.atoms.size()>0, ExcInternalError());
 
 #ifdef DEBUG
-    for (int a=0; a<atomicity; a++)
-      for (int b=a+1; b<atomicity; b++)
-        Assert(molecule.atoms[a].type <= molecule.atoms[b].type,
-               ExcMessage("Atoms in the molecule are not sorted according "
-                          "to their atom types."));
+  for (int a=0; a<atomicity; a++)
+    for (int b=a+1; b<atomicity; b++)
+      Assert(molecule.atoms[a].type <= molecule.atoms[b].type,
+             ExcMessage("Atoms in the molecule are not sorted according "
+                        "to their atom types."));
 #endif
 
-    return molecule.atoms[0].initial_position;
-  }
+  return molecule.atoms[0].initial_position;
+}
 
 
 
-  /**
-   * Return the least distance squared between atoms of @p molecule_A and
-   * @p molecule_B.
-   */
-  template<int spacedim, int atomicity>
-  inline
-  double
-  least_distance_squared (const Molecule<spacedim, atomicity> &molecule_A,
-                          const Molecule<spacedim, atomicity> &molecule_B)
-  {
-    double squared_distance = std::numeric_limits<double>::max();
+/**
+ * Return the least distance squared between atoms of @p molecule_A and
+ * @p molecule_B.
+ */
+template<int spacedim, int atomicity>
+inline
+double
+least_distance_squared (const Molecule<spacedim, atomicity> &molecule_A,
+                        const Molecule<spacedim, atomicity> &molecule_B)
+{
+  double squared_distance = std::numeric_limits<double>::max();
 
-    for (const auto &atom_A : molecule_A.atoms)
-      for (const auto &atom_B : molecule_B.atoms)
-        {
-          const double tmp_squared_distance =
-            atom_A.position.distance_square(atom_B.position);
+  for (const auto &atom_A : molecule_A.atoms)
+    for (const auto &atom_B : molecule_B.atoms)
+      {
+        const double tmp_squared_distance =
+          atom_A.position.distance_square(atom_B.position);
 
-          if (tmp_squared_distance < squared_distance)
-            squared_distance = tmp_squared_distance;
-        }
+        if (tmp_squared_distance < squared_distance)
+          squared_distance = tmp_squared_distance;
+      }
 
-    return squared_distance;
-  }
+  return squared_distance;
+}
 
 
-
-} // namespace dealiiqc
-
+DEAL_II_QC_NAMESPACE_CLOSE
 
 
 #endif // __dealii_qc_molecule_h

--- a/include/deal.II-qc/atom/molecule_handler.h
+++ b/include/deal.II-qc/atom/molecule_handler.h
@@ -5,97 +5,100 @@
 
 #include <deal.II-qc/configure/configure_qc.h>
 
-namespace dealiiqc
+
+DEAL_II_QC_NAMESPACE_OPEN
+
+
+/**
+ * A class to manage the cell based molecule data of the system
+ * (see CellMoleculeData).
+ *
+ * deal.II-qc can use multiple machines connected via MPI to parallelize
+ * computations of (quasicontinuum approximation of) energy and its gradient.
+ *
+ * <h3>Local ownership</h3>
+ *
+ * In an MPI context, when a parallel::shared::Triangulation
+ * is employed (which keeps the information of the entire mesh on each
+ * process) the concept of a local ownership is used.
+ * In a parallel::shared::Triangulation, each cell is owned by exactly one
+ * MPI process leading to a partitioning of the underlying mesh into disjoint
+ * locally owned cells among MPI processes. The cells stored on an MPI process
+ * that are not owned by this process are called ghost cells of the MPI
+ * process.
+ *
+ * <h3>Cells and molecules association</h3>
+ *
+ * In order to define kinematic constraints on lattice site positions,
+ * we need to associate cells and molecules. The association between a cell
+ * and molecule is done in the following way. In the Lagrangian (undeformed)
+ * configuration of the system given the location of a molecule, we find a
+ * cell which contains it. After such an association the concept of local
+ * ownership also applies to the molecules of the system.
+ *
+ * <h3>Locally relevant cells and molecules</h3>
+ *
+ * Each MPI process is responsible for computation of energy (and its
+ * gradient) of the locally owned molecules (or a subset of locally owned
+ * molecule by applying certain sampling rules). Molecules which are not
+ * owned by an MPI process are called ghost molecules. All the molecules
+ * which interact with the locally owned molecules of an MPI process are
+ * called locally relevant molecules and their associated cells are the
+ * locally relevant cells of the MPI process. Therefore, each MPI process
+ * needs to store the updated copies of all locally relevant molecules.
+ *
+ * To limit memory usage and communication overhead, we would want to limit
+ * the number of ghost molecules stored in MPI processes. For this reason,
+ * we assume that it is enough to find locally relevant, ghost cells and
+ * molecules of each process with in a distance of
+ * ConfigureQC::ghost_cell_layer_thickness from the locally owned cells only
+ * once in Lagrangian (undeformed) configuration of the system. Which
+ * certainly holds for the case of small deformations.
+ * For all other cases, it can be done using careful or custom partitioning
+ * of the triangulation and choosing sufficiently large
+ * ConfigureQC::ghost_cell_layer_thickness.
+ *
+ * It can also be stated that a locally relevant cell is one which is either
+ * a locally owned cell or a ghost cell within a
+ * ConfigureQC::ghost_cell_layer_thickness (which is greater than the
+ * interaction radius between molecules) from the locally owned cells of an
+ * MPI process.
+ *
+ * (refer to deal.II documentation for further details about
+ * parallel::shared::Triangulation).
+ */
+template<int dim, int atomicity=1, int spacedim=dim>
+class MoleculeHandler
 {
+public:
 
   /**
-   * A class to manage the cell based molecule data of the system
-   * (see CellMoleculeData).
-   *
-   * deal.II-qc can use multiple machines connected via MPI to parallelize
-   * computations of (quasicontinuum approximation of) energy and its gradient.
-   *
-   * <h3>Local ownership</h3>
-   *
-   * In an MPI context, when a parallel::shared::Triangulation
-   * is employed (which keeps the information of the entire mesh on each
-   * process) the concept of a local ownership is used.
-   * In a parallel::shared::Triangulation, each cell is owned by exactly one
-   * MPI process leading to a partitioning of the underlying mesh into disjoint
-   * locally owned cells among MPI processes. The cells stored on an MPI process
-   * that are not owned by this process are called ghost cells of the MPI
-   * process.
-   *
-   * <h3>Cells and molecules association</h3>
-   *
-   * In order to define kinematic constraints on lattice site positions,
-   * we need to associate cells and molecules. The association between a cell
-   * and molecule is done in the following way. In the Lagrangian (undeformed)
-   * configuration of the system given the location of a molecule, we find a
-   * cell which contains it. After such an association the concept of local
-   * ownership also applies to the molecules of the system.
-   *
-   * <h3>Locally relevant cells and molecules</h3>
-   *
-   * Each MPI process is responsible for computation of energy (and its
-   * gradient) of the locally owned molecules (or a subset of locally owned
-   * molecule by applying certain sampling rules). Molecules which are not
-   * owned by an MPI process are called ghost molecules. All the molecules
-   * which interact with the locally owned molecules of an MPI process are
-   * called locally relevant molecules and their associated cells are the
-   * locally relevant cells of the MPI process. Therefore, each MPI process
-   * needs to store the updated copies of all locally relevant molecules.
-   *
-   * To limit memory usage and communication overhead, we would want to limit
-   * the number of ghost molecules stored in MPI processes. For this reason,
-   * we assume that it is enough to find locally relevant, ghost cells and
-   * molecules of each process with in a distance of
-   * ConfigureQC::ghost_cell_layer_thickness from the locally owned cells only
-   * once in Lagrangian (undeformed) configuration of the system. Which
-   * certainly holds for the case of small deformations.
-   * For all other cases, it can be done using careful or custom partitioning
-   * of the triangulation and choosing sufficiently large
-   * ConfigureQC::ghost_cell_layer_thickness.
-   *
-   * It can also be stated that a locally relevant cell is one which is either
-   * a locally owned cell or a ghost cell within a
-   * ConfigureQC::ghost_cell_layer_thickness (which is greater than the
-   * interaction radius between molecules) from the locally owned cells of an
-   * MPI process.
-   *
-   * (refer to deal.II documentation for further details about
-   * parallel::shared::Triangulation).
+   * Constructor takes in a ConfigureQC object @p configure_qc.
    */
-  template<int dim, int atomicity=1, int spacedim=dim>
-  class MoleculeHandler
-  {
-  public:
+  MoleculeHandler (const ConfigureQC &configure_qc);
 
-    /**
-     * Constructor takes in a ConfigureQC object @p configure_qc.
-     */
-    MoleculeHandler (const ConfigureQC &configure_qc);
-
-    /**
-     * Return the neighbor lists of @p cell_energy_molecules.
-     *
-     * This function can be called as often as one deems necessary. The function
-     * currently assumes that the deformation is small that the neighbor lists
-     * are exactly the same as that of reference (undeformed) configuration.
-     */
-    types::CellMoleculeNeighborLists<dim, atomicity, spacedim>
-    get_neighbor_lists (const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules) const;
+  /**
+   * Return the neighbor lists of @p cell_energy_molecules.
+   *
+   * This function can be called as often as one deems necessary. The function
+   * currently assumes that the deformation is small that the neighbor lists
+   * are exactly the same as that of reference (undeformed) configuration.
+   */
+  types::CellMoleculeNeighborLists<dim, atomicity, spacedim>
+  get_neighbor_lists (const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules) const;
 
 
-  protected:
+protected:
 
-    /**
-     * A constant reference to ConfigureQC object
-     */
-    const ConfigureQC &configure_qc;
+  /**
+   * A constant reference to ConfigureQC object
+   */
+  const ConfigureQC &configure_qc;
 
-  };
+};
 
-} /* namespace dealiiqc */
+
+DEAL_II_QC_NAMESPACE_CLOSE
+
 
 #endif // __dealii_qc_molecule_handler_h

--- a/include/deal.II-qc/atom/parse_atom_data.h
+++ b/include/deal.II-qc/atom/parse_atom_data.h
@@ -11,107 +11,111 @@
 
 #include <deal.II-qc/atom/molecule.h>
 
-namespace dealiiqc
+
+DEAL_II_QC_NAMESPACE_OPEN
+
+
+using namespace dealii;
+
+/**
+ * A class to parse atom data stream.
+ */
+template<int spacedim, int atomicity=1>
+class ParseAtomData
 {
-  using namespace dealii;
+public:
 
   /**
-   * A class to parse atom data stream.
+   * Constructor takes data
    */
-  template<int spacedim, int atomicity=1>
-  class ParseAtomData
-  {
-  public:
+  ParseAtomData();
 
-    /**
-     * Constructor takes data
-     */
-    ParseAtomData();
+  DeclException1 (ExcIrrelevant,
+                  unsigned int,
+                  << "Input atom data stream contains atom attributes "
+                  << "at line number: " << arg1 << " "
+                  << "which are either not supported within QC formulation "
+                  << "or not yet implemented");
 
-    DeclException1 (ExcIrrelevant,
-                    unsigned int,
-                    << "Input atom data stream contains atom attributes "
-                    << "at line number: " << arg1 << " "
-                    << "which are either not supported within QC formulation "
-                    << "or not yet implemented");
+  DeclException1 (ExcReadFailed,
+                  unsigned int,
+                  << "Could not read atom data stream "
+                  << "at line number: " << arg1 << " "
+                  << "Either end of stream reached unexpectedly or "
+                  << "important atom attributes are not mentioned!");
 
-    DeclException1 (ExcReadFailed,
-                    unsigned int,
-                    << "Could not read atom data stream "
-                    << "at line number: " << arg1 << " "
-                    << "Either end of stream reached unexpectedly or "
-                    << "important atom attributes are not mentioned!");
+  DeclException2 (ExcInvalidValue,
+                  unsigned int,
+                  std::string,
+                  << "Could not parse " << arg2 << " or "
+                  << "invalid " << arg2 << " read "
+                  << "at line number: " << arg1 );
 
-    DeclException2 (ExcInvalidValue,
-                    unsigned int,
-                    std::string,
-                    << "Could not parse " << arg2 << " or "
-                    << "invalid " << arg2 << " read "
-                    << "at line number: " << arg1 );
+  /**
+   * Parse @p is input stream and initialize all the atom and moleucle
+   * attributes. The input stream is allowed to have multiple Masses and Atoms
+   * keyword section. In such cases the old atom attributes will be
+   * overwritten.
+   * @param[in] is input stream
+   * @param[out] molecules container to store atom and molecule attributes
+   * @param[out] charges container to charges of different atom species
+   * @param[out] masses container to store masses of different atom species
+   */
+  void parse (std::istream                               &is,
+              std::vector<Molecule<spacedim, atomicity>> &molecules,
+              std::vector<types::charge>                 &charges,
+              std::vector<double>                        &masses);
 
-    /**
-     * Parse @p is input stream and initialize all the atom and moleucle
-     * attributes. The input stream is allowed to have multiple Masses and Atoms
-     * keyword section. In such cases the old atom attributes will be
-     * overwritten.
-     * @param[in] is input stream
-     * @param[out] molecules container to store atom and molecule attributes
-     * @param[out] charges container to charges of different atom species
-     * @param[out] masses container to store masses of different atom species
-     */
-    void parse (std::istream                               &is,
-                std::vector<Molecule<spacedim, atomicity>> &molecules,
-                std::vector<types::charge>                 &charges,
-                std::vector<double>                        &masses);
+private:
 
-  private:
+  /**
+   * Remove from @p input string all comments (content after #) and
+   * all standard whitespace characters (including * '<tt>\\t</tt>',
+   * '<tt>\\n</tt>', and '<tt>\\r</tt>') at the beginning, and at the end
+   * and return the resulting string.
+   */
+  std::string strip (const std::string &input);
 
-    /**
-     * Remove from @p input string all comments (content after #) and
-     * all standard whitespace characters (including * '<tt>\\t</tt>',
-     * '<tt>\\n</tt>', and '<tt>\\r</tt>') at the beginning, and at the end
-     * and return the resulting string.
-     */
-    std::string strip (const std::string &input);
+  /**
+   * Parse atoms data from @p is input stream under Atoms keyword section.
+   * The input stream should be at the line after the keyword Masses.
+   * @param[in] is input stream
+   * @param[out] molecules container to store atom and molecule attributes
+   * @param[out] charges container to charges of different atom species
+   */
+  void parse_atoms (std::istream                               &is,
+                    std::vector<Molecule<spacedim, atomicity>> &molecules,
+                    std::vector<types::charge>                 &charges);
 
-    /**
-     * Parse atoms data from @p is input stream under Atoms keyword section.
-     * The input stream should be at the line after the keyword Masses.
-     * @param[in] is input stream
-     * @param[out] molecules container to store atom and molecule attributes
-     * @param[out] charges container to charges of different atom species
-     */
-    void parse_atoms (std::istream                               &is,
-                      std::vector<Molecule<spacedim, atomicity>> &molecules,
-                      std::vector<types::charge>                 &charges);
+  /**
+   * Parse @p is input stream for mass entries under Masses keyword section
+   * to obtain @p masses, a vector of masses of different atom types and
+   * write the result into @p masses. The input stream should be at the line
+   * after the keyword Masses
+   */
+  void parse_masses (std::istream        &is,
+                     std::vector<double> &masses);
 
-    /**
-     * Parse @p is input stream for mass entries under Masses keyword section
-     * to obtain @p masses, a vector of masses of different atom types and
-     * write the result into @p masses. The input stream should be at the line
-     * after the keyword Masses
-     */
-    void parse_masses (std::istream        &is,
-                       std::vector<double> &masses);
+  /**
+   * Number of atoms read from the input stream.
+   */
+  types::global_atom_index n_atoms;
 
-    /**
-     * Number of atoms read from the input stream.
-     */
-    types::global_atom_index n_atoms;
+  /**
+   * Number of atom types read from the input stream.
+   */
+  size_t n_atom_types;
 
-    /**
-     * Number of atom types read from the input stream.
-     */
-    size_t n_atom_types;
+  /**
+   * Line number of the input stream as it is read.
+   * Used to inform the user at which line number reading failed.
+   */
+  unsigned int line_no;
 
-    /**
-     * Line number of the input stream as it is read.
-     * Used to inform the user at which line number reading failed.
-     */
-    unsigned int line_no;
+};
 
-  };
 
-} /* namespace dealiiqc */
+DEAL_II_QC_NAMESPACE_CLOSE
+
 
 #endif /* __dealii_qc_parse_atom_data_h */

--- a/include/deal.II-qc/utilities.h
+++ b/include/deal.II-qc/utilities.h
@@ -54,199 +54,209 @@
 
 
 
-namespace dealiiqc
+/***************************************************************************
+ * Two macro names that we put at the top and bottom of all deal.II-qc files
+ * and that will be expanded to "namespace dealiiqc {" and "}".
+ */
+#define DEAL_II_QC_NAMESPACE_OPEN   namespace dealiiqc {
+#define DEAL_II_QC_NAMESPACE_CLOSE  }
+
+
+DEAL_II_QC_NAMESPACE_OPEN
+
+
+/**
+ * Custom types used inside dealiiqc.
+ */
+namespace types
 {
+  /**
+   * The type used for global indices of atoms.
+   * In order to have 64-bit unsigned integers (more than 4 billion),
+   * build deal.II with support for 64-bit integers.
+   * The data type always indicates an unsigned integer type.
+   */
+  typedef  dealii::types::global_dof_index global_atom_index;
 
   /**
-   * Custom types used inside dealiiqc.
+   * The type used for global indices of molecules.
    */
-  namespace types
-  {
-    /**
-     * The type used for global indices of atoms.
-     * In order to have 64-bit unsigned integers (more than 4 billion),
-     * build deal.II with support for 64-bit integers.
-     * The data type always indicates an unsigned integer type.
-     */
-    typedef  dealii::types::global_dof_index global_atom_index;
+  typedef  global_atom_index global_molecule_index;
 
-    /**
-     * The type used for global indices of molecules.
-     */
-    typedef  global_atom_index global_molecule_index;
-
-    // TODO: Use of correct charge units; Use charge_t for book keeping.
-    /**
-     * The type used for storing charge of the atom.
-     * Computations with charge of atoms don't need high precision.
-     */
-    typedef float charge;
-
-    /**
-     * The type used for identifying atom types. The enumeration starts
-     * from 0.
-     */
-    typedef unsigned char atom_type;
-
-    /**
-     * A typedef for mesh.
-     */
-    template<int dim, int spacedim=dim>
-    using MeshType = dealii::DoFHandler<dim, spacedim>;
-
-    /**
-     * A typedef for DoFHandler's active_cell_iterator for ease of use.
-     */
-    template<int dim, int spacedim=dim>
-    using CellIteratorType =
-      typename MeshType<dim, spacedim>::active_cell_iterator;
-
-    /**
-     * A typedef for DoFHandler's const active_cell_iterator for ease of use.
-     */
-    template<int dim, int spacedim=dim>
-    using ConstCellIteratorType =
-      const CellIteratorType<dim, spacedim>;
-
-  } //typedefs
-
-
+  // TODO: Use of correct charge units; Use charge_t for book keeping.
+  /**
+   * The type used for storing charge of the atom.
+   * Computations with charge of atoms don't need high precision.
+   */
+  typedef float charge;
 
   /**
-   * A namespace for certain fixed numbers.
+   * The type used for identifying atom types. The enumeration starts
+   * from 0.
    */
-  namespace numbers
-  {
-    /**
-     * A number representing invalid cluster weight.
-     */
-    static const double
-    invalid_cluster_weight = std::numeric_limits<double>::signaling_NaN();
-
-  } // numbers
-
-
+  typedef unsigned char atom_type;
 
   /**
-   * Make sure that sscanf doesn't pickup spaces as unsigned char
-   * while parsing atom data stream.
+   * A typedef for mesh.
    */
+  template<int dim, int spacedim=dim>
+  using MeshType = dealii::DoFHandler<dim, spacedim>;
+
+  /**
+   * A typedef for DoFHandler's active_cell_iterator for ease of use.
+   */
+  template<int dim, int spacedim=dim>
+  using CellIteratorType =
+    typename MeshType<dim, spacedim>::active_cell_iterator;
+
+  /**
+   * A typedef for DoFHandler's const active_cell_iterator for ease of use.
+   */
+  template<int dim, int spacedim=dim>
+  using ConstCellIteratorType =
+    const CellIteratorType<dim, spacedim>;
+
+} //typedefs
+
+
+
+/**
+ * A namespace for certain fixed numbers.
+ */
+namespace numbers
+{
+  /**
+   * A number representing invalid cluster weight.
+   */
+  static const double
+  invalid_cluster_weight = std::numeric_limits<double>::signaling_NaN();
+
+} // numbers
+
+
+
+/**
+ * Make sure that sscanf doesn't pickup spaces as unsigned char
+ * while parsing atom data stream.
+ */
 #define UC_SCANF_STR "%hhu"
 
-  namespace Utilities
+namespace Utilities
+{
+  using namespace dealii;
+
+
+
+  // TODO: Add a test for this function.
+  /**
+   * Find the closest vertex of a given cell @p cell to a given Point @p and
+   * return a pair of its number and the squared distance.
+   */
+  template<int dim>
+  inline
+  std::pair<unsigned int, double>
+  find_closest_vertex (const Point<dim> &p,
+                       const typename Triangulation<dim>::cell_iterator cell)
   {
-    using namespace dealii;
+    // Throw exception if the given cell is is not in a valid
+    // cell iterator state.
+    AssertThrow (cell->state() == IteratorState::valid,
+                 ExcMessage ("The given cell iterator is not in a "
+                             "valid iterator state"));
 
+    // Assume the first vertex is the closest at first.
+    double squared_distance = p.distance_square(cell->vertex(0));
+    unsigned int vertex_number = 0;
 
-
-    // TODO: Add a test for this function.
-    /**
-     * Find the closest vertex of a given cell @p cell to a given Point @p and
-     * return a pair of its number and the squared distance.
-     */
-    template<int dim>
-    inline
-    std::pair<unsigned int, double>
-    find_closest_vertex (const Point<dim> &p,
-                         const typename Triangulation<dim>::cell_iterator cell)
-    {
-      // Throw exception if the given cell is is not in a valid
-      // cell iterator state.
-      AssertThrow (cell->state() == IteratorState::valid,
-                   ExcMessage ("The given cell iterator is not in a "
-                               "valid iterator state"));
-
-      // Assume the first vertex is the closest at first.
-      double squared_distance = p.distance_square(cell->vertex(0));
-      unsigned int vertex_number = 0;
-
-      // Loop over all the other vertices to search for closest vertex.
-      for (unsigned int v=1; v<GeometryInfo<dim>::vertices_per_cell; ++v)
-        {
-          const double p_squared_distance = p.distance_square(cell->vertex(v));
-          if (p_squared_distance < squared_distance)
-            {
-              squared_distance = p_squared_distance;
-              vertex_number = v;
-            }
-        }
-      return std::make_pair(vertex_number, squared_distance);
-    }
-
-
-
-    /**
-     * Utility function that returns true if a point @p p is outside a bounding
-     * box. The box is specified by two points @p minp and @p maxp (the order of
-     * specifying points is important).
-     */
-    template<int dim>
-    inline
-    bool
-    is_outside_bounding_box( const Point<dim> &minp,
-                             const Point<dim> &maxp,
-                             const Point<dim> &p)
-    {
-      for (unsigned int d=0; d<dim; ++d)
-        if ( (minp[d] > p[d]) || (p[d] > maxp[d]) )
+    // Loop over all the other vertices to search for closest vertex.
+    for (unsigned int v=1; v<GeometryInfo<dim>::vertices_per_cell; ++v)
+      {
+        const double p_squared_distance = p.distance_square(cell->vertex(v));
+        if (p_squared_distance < squared_distance)
           {
-            return true;
+            squared_distance = p_squared_distance;
+            vertex_number = v;
           }
-
-      return false;
-    }
-
-
-
-    /**
-     * Given a string that contains a list of @p minor_delimiter separated
-     * text separated by a @p major_delimiter, split it into its components,
-     * remove leading and trailing spaces.
-     *
-     * The input string can end without specifying any delimiters (possibly
-     * followed by an arbitrary amount of whitespace). For example,
-     * @code
-     *   Utilities::split_list_of_string_lists
-     *   ("abc, def; ghi; j, k, l; ", ';', ',');
-     * @endcode
-     * yields the same 3-element list of sub-lists output
-     * <code>{ {"abc", "def"},{"ghi"}, {"j", "k", "l"}}</code>
-     * as you would get if the input had been
-     * @code
-     *   Utilities::split_list_of_string_lists
-     *   ("abc, def; ghi; j, k, l", ';', ',');
-     * @endcode
-     * or
-     * @code
-     *   Utilities::split_list_of_string_lists
-     *   ("abc, def; ghi; j, k, l;", ';', ',');
-     * @endcode
-     */
-    inline
-    std::vector<std::vector<std::string> >
-    split_list_of_string_lists (const std::string &s,
-                                const char major_delimiter = ';',
-                                const char minor_delimiter = ',')
-    {
-      AssertThrow (major_delimiter!=minor_delimiter,
-                   ExcMessage("Invalid major and minor delimiters provided!"));
-
-      std::vector<std::vector<std::string>> res;
-
-      const std::vector<std::string> coeffs_per_type =
-        dealii::Utilities::split_string_list (s,
-                                              major_delimiter);
-      res.resize(coeffs_per_type.size());
-      for (unsigned int i = 0; i < coeffs_per_type.size(); ++i)
-        res[i] = dealii::Utilities::split_string_list (coeffs_per_type[i],
-                                                       minor_delimiter);
-      return res;
-    }
+      }
+    return std::make_pair(vertex_number, squared_distance);
+  }
 
 
 
-  } // Utilities
+  /**
+   * Utility function that returns true if a point @p p is outside a bounding
+   * box. The box is specified by two points @p minp and @p maxp (the order of
+   * specifying points is important).
+   */
+  template<int dim>
+  inline
+  bool
+  is_outside_bounding_box( const Point<dim> &minp,
+                           const Point<dim> &maxp,
+                           const Point<dim> &p)
+  {
+    for (unsigned int d=0; d<dim; ++d)
+      if ( (minp[d] > p[d]) || (p[d] > maxp[d]) )
+        {
+          return true;
+        }
 
-} // namespace dealiiqc
+    return false;
+  }
+
+
+
+  /**
+   * Given a string that contains a list of @p minor_delimiter separated
+   * text separated by a @p major_delimiter, split it into its components,
+   * remove leading and trailing spaces.
+   *
+   * The input string can end without specifying any delimiters (possibly
+   * followed by an arbitrary amount of whitespace). For example,
+   * @code
+   *   Utilities::split_list_of_string_lists
+   *   ("abc, def; ghi; j, k, l; ", ';', ',');
+   * @endcode
+   * yields the same 3-element list of sub-lists output
+   * <code>{ {"abc", "def"},{"ghi"}, {"j", "k", "l"}}</code>
+   * as you would get if the input had been
+   * @code
+   *   Utilities::split_list_of_string_lists
+   *   ("abc, def; ghi; j, k, l", ';', ',');
+   * @endcode
+   * or
+   * @code
+   *   Utilities::split_list_of_string_lists
+   *   ("abc, def; ghi; j, k, l;", ';', ',');
+   * @endcode
+   */
+  inline
+  std::vector<std::vector<std::string> >
+  split_list_of_string_lists (const std::string &s,
+                              const char major_delimiter = ';',
+                              const char minor_delimiter = ',')
+  {
+    AssertThrow (major_delimiter!=minor_delimiter,
+                 ExcMessage("Invalid major and minor delimiters provided!"));
+
+    std::vector<std::vector<std::string>> res;
+
+    const std::vector<std::string> coeffs_per_type =
+      dealii::Utilities::split_string_list (s,
+                                            major_delimiter);
+    res.resize(coeffs_per_type.size());
+    for (unsigned int i = 0; i < coeffs_per_type.size(); ++i)
+      res[i] = dealii::Utilities::split_string_list (coeffs_per_type[i],
+                                                     minor_delimiter);
+    return res;
+  }
+
+
+
+} // Utilities
+
+
+DEAL_II_QC_NAMESPACE_CLOSE
+
 
 #endif /* __dealii_qc_utility_h */

--- a/source/atom/cell_molecule_tools.cc
+++ b/source/atom/cell_molecule_tools.cc
@@ -5,276 +5,283 @@
 #include <deal.II-qc/atom/parse_atom_data.h>
 
 
-namespace dealiiqc
+DEAL_II_QC_NAMESPACE_OPEN
+
+
+namespace CellMoleculeTools
 {
 
-  namespace CellMoleculeTools
+  template<int dim, int atomicity, int spacedim>
+  std::pair
+  <
+  types::CellMoleculeConstIteratorRangeType<dim, atomicity, spacedim>
+  ,
+  unsigned int
+  >
+  molecules_range_in_cell
+  (const types::CellIteratorType<dim, spacedim>                     &cell,
+   const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules)
   {
+    AssertThrow (!cell_molecules.empty(),
+                 ExcMessage("The given CellMoleculeContainer is empty!"));
 
-    template<int dim, int atomicity, int spacedim>
-    std::pair
-    <
-    types::CellMoleculeConstIteratorRangeType<dim, atomicity, spacedim>
-    ,
-    unsigned int
-    >
-    molecules_range_in_cell
-    (const types::CellIteratorType<dim, spacedim>                     &cell,
-     const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules)
-    {
-      AssertThrow (!cell_molecules.empty(),
-                   ExcMessage("The given CellMoleculeContainer is empty!"));
+    const types::CellMoleculeConstIteratorRangeType<dim, atomicity, spacedim>
+    cell_molecule_range = cell_molecules.equal_range(cell);
 
-      const types::CellMoleculeConstIteratorRangeType<dim, atomicity, spacedim>
-      cell_molecule_range = cell_molecules.equal_range(cell);
+    const types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+    &cell_molecule_range_begin = cell_molecule_range.first,
+     &cell_molecule_range_end  = cell_molecule_range.second;
 
-      const types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-      &cell_molecule_range_begin = cell_molecule_range.first,
-       &cell_molecule_range_end  = cell_molecule_range.second;
-
-      if (cell_molecule_range_begin == cell_molecule_range_end)
-        // Quickly return the following if cell is not
-        // found in the CellMoleculeContainerType object
-        return std::make_pair(std::make_pair(cell_molecule_range_begin,
-                                             cell_molecule_range_end),
-                              0);
-
-      // Faster to get the number of molecules in the active cell by
-      // computing the distance between first and second iterators
-      // instead of calling count on cell_molecules.
-      // Here we implicitly cast to unsigned int, but this should be OK as
-      // we check that the result is the same as calling count()
-      const unsigned int
-      n_molecules_in_cell = std::distance (cell_molecule_range.first,
-                                           cell_molecule_range.second);
-
-      Assert (n_molecules_in_cell == cell_molecules.count(cell),
-              ExcMessage("The number of molecules or energy molecules in the "
-                         "cell counted using the distance between the iterator "
-                         "ranges yields a different result than "
-                         "cell_molecules.count(cell) or"
-                         "cell_energy_molecules.count(cell)."));
-
+    if (cell_molecule_range_begin == cell_molecule_range_end)
+      // Quickly return the following if cell is not
+      // found in the CellMoleculeContainerType object
       return std::make_pair(std::make_pair(cell_molecule_range_begin,
                                            cell_molecule_range_end),
-                            n_molecules_in_cell);
-    }
+                            0);
+
+    // Faster to get the number of molecules in the active cell by
+    // computing the distance between first and second iterators
+    // instead of calling count on cell_molecules.
+    // Here we implicitly cast to unsigned int, but this should be OK as
+    // we check that the result is the same as calling count()
+    const unsigned int
+    n_molecules_in_cell = std::distance (cell_molecule_range.first,
+                                         cell_molecule_range.second);
+
+    Assert (n_molecules_in_cell == cell_molecules.count(cell),
+            ExcMessage("The number of molecules or energy molecules in the "
+                       "cell counted using the distance between the iterator "
+                       "ranges yields a different result than "
+                       "cell_molecules.count(cell) or"
+                       "cell_energy_molecules.count(cell)."));
+
+    return std::make_pair(std::make_pair(cell_molecule_range_begin,
+                                         cell_molecule_range_end),
+                          n_molecules_in_cell);
+  }
 
 
 
-    template<int dim, int atomicity=1, int spacedim=dim>
-    unsigned int
-    n_cluster_molecules_in_cell
-    (const types::CellIteratorType<dim, spacedim> &cell,
-     const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules)
-    {
-      const types::CellMoleculeConstIteratorRangeType<dim, atomicity, spacedim>
-      cell_molecule_range = cell_energy_molecules.equal_range(cell);
+  template<int dim, int atomicity=1, int spacedim=dim>
+  unsigned int
+  n_cluster_molecules_in_cell
+  (const types::CellIteratorType<dim, spacedim> &cell,
+   const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules)
+  {
+    const types::CellMoleculeConstIteratorRangeType<dim, atomicity, spacedim>
+    cell_molecule_range = cell_energy_molecules.equal_range(cell);
 
-      const types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-      &cell_molecule_range_begin = cell_molecule_range.first,
-       &cell_molecule_range_end  = cell_molecule_range.second;
+    const types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+    &cell_molecule_range_begin = cell_molecule_range.first,
+     &cell_molecule_range_end  = cell_molecule_range.second;
 
-      if (cell_molecule_range_begin == cell_molecule_range_end)
-        // Quickly return the following if cell is not
-        // found in the CellMoleculeContainerType object
-        return 0;
+    if (cell_molecule_range_begin == cell_molecule_range_end)
+      // Quickly return the following if cell is not
+      // found in the CellMoleculeContainerType object
+      return 0;
 
-      unsigned int n_cluster_molecules_in_this_cell = 0;
+    unsigned int n_cluster_molecules_in_this_cell = 0;
 
-      for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-           cell_molecule_iterator  = cell_molecule_range_begin;
-           cell_molecule_iterator != cell_molecule_range_end;
-           cell_molecule_iterator++)
-        {
-          Assert (cell_molecule_iterator->second.cluster_weight != numbers::invalid_cluster_weight,
-                  ExcMessage("At least one of the molecule's cluster weight is "
-                             "not initialized to a valid number."
-                             "This function should be called only after "
-                             "setting up correct cluster weights."));
-          if (cell_molecule_iterator->second.cluster_weight != 0)
-            n_cluster_molecules_in_this_cell++;
-        }
+    for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+         cell_molecule_iterator  = cell_molecule_range_begin;
+         cell_molecule_iterator != cell_molecule_range_end;
+         cell_molecule_iterator++)
+      {
+        Assert (cell_molecule_iterator->second.cluster_weight != numbers::invalid_cluster_weight,
+                ExcMessage("At least one of the molecule's cluster weight is "
+                           "not initialized to a valid number."
+                           "This function should be called only after "
+                           "setting up correct cluster weights."));
+        if (cell_molecule_iterator->second.cluster_weight != 0)
+          n_cluster_molecules_in_this_cell++;
+      }
 
-      return n_cluster_molecules_in_this_cell;
-    }
+    return n_cluster_molecules_in_this_cell;
+  }
 
 
 
-    template<int dim, int atomicity, int spacedim>
-    CellMoleculeData<dim, atomicity, spacedim>
-    build_cell_molecule_data (std::istream                         &is,
-                              const types::MeshType<dim, spacedim> &mesh,
-                              double          ghost_cell_layer_thickness)
-    {
-      // TODO: Assign atoms to cells as we parse atom data ?
-      //       relevant for when we have a large collection of atoms.
-      std::vector<Molecule<spacedim, atomicity>> vector_molecules;
-      ParseAtomData<spacedim, atomicity> atom_parser;
+  template<int dim, int atomicity, int spacedim>
+  CellMoleculeData<dim, atomicity, spacedim>
+  build_cell_molecule_data (std::istream                         &is,
+                            const types::MeshType<dim, spacedim> &mesh,
+                            double          ghost_cell_layer_thickness)
+  {
+    // TODO: Assign atoms to cells as we parse atom data ?
+    //       relevant for when we have a large collection of atoms.
+    std::vector<Molecule<spacedim, atomicity>> vector_molecules;
+    ParseAtomData<spacedim, atomicity> atom_parser;
 
-      // Prepare cell molecule data in this container.
-      CellMoleculeData<dim, atomicity, spacedim> cell_molecule_data;
+    // Prepare cell molecule data in this container.
+    CellMoleculeData<dim, atomicity, spacedim> cell_molecule_data;
 
-      cell_molecule_data.charges = NULL;
-      std::vector<types::charge> charges;
-      auto &masses         = cell_molecule_data.masses;
-      auto &cell_molecules = cell_molecule_data.cell_molecules;
+    cell_molecule_data.charges = NULL;
+    std::vector<types::charge> charges;
+    auto &masses         = cell_molecule_data.masses;
+    auto &cell_molecules = cell_molecule_data.cell_molecules;
 
-      if ( !is.eof() )
-        atom_parser.parse (is, vector_molecules, charges, masses);
-      else
-        AssertThrow(false,
-                    ExcMessage("The provided input stream is empty."));
+    if ( !is.eof() )
+      atom_parser.parse (is, vector_molecules, charges, masses);
+    else
+      AssertThrow(false,
+                  ExcMessage("The provided input stream is empty."));
 
-      cell_molecule_data.charges = std::make_shared<std::vector<types::charge>>(charges);
+    cell_molecule_data.charges =
+      std::make_shared<std::vector<types::charge>>(charges);
 
-      const unsigned int n_vertices =  mesh.get_triangulation().n_vertices();
+    const unsigned int n_vertices =  mesh.get_triangulation().n_vertices();
 
-      // In order to speed-up finding an active cell around atoms through
-      // find_active_cell_around_point(), we will need to construct a
-      // mask for vertices of locally owned cells and ghost cells
-      std::vector<bool> locally_active_vertices( n_vertices,
-                                                 false);
+    // In order to speed-up finding an active cell around atoms through
+    // find_active_cell_around_point(), we will need to construct a
+    // mask for vertices of locally owned cells and ghost cells
+    std::vector<bool> locally_active_vertices( n_vertices,
+                                               false);
 
-      // Loop through all the locally owned cells and
-      // mark (true) all the vertices of the locally owned cells.
-      for (typename types::MeshType<dim, spacedim>::active_cell_iterator
-           cell = mesh.begin_active();
-           cell != mesh.end(); ++cell)
-        if (cell->is_locally_owned())
-          for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
-            locally_active_vertices[cell->vertex_index(v)] = true;
-
-      // This MPI process also needs to know certain active ghost cells
-      // within a certain distance from locally owned cells.
-      // This MPI process will also keep copy of atoms associated to
-      // such active ghost cells.
-      // ghost_cells vector will contain all such active ghost cells.
-      // If the total number of MPI processes is just one,
-      // the size of ghost_cells vector is zero.
-      const std::vector<typename types::MeshType<dim, spacedim>::active_cell_iterator>
-      ghost_cells =
-        GridTools::compute_ghost_cell_layer_within_distance (mesh,
-                                                             ghost_cell_layer_thickness);
-
-      // Loop through all the ghost cells computed above and
-      // mark (true) all the vertices of the locally owned and active
-      // ghost cells within ConfigureQC::ghost_cell_layer_thickness.
-      for (auto cell : ghost_cells)
+    // Loop through all the locally owned cells and
+    // mark (true) all the vertices of the locally owned cells.
+    for (typename types::MeshType<dim, spacedim>::active_cell_iterator
+         cell = mesh.begin_active();
+         cell != mesh.end(); ++cell)
+      if (cell->is_locally_owned())
         for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
           locally_active_vertices[cell->vertex_index(v)] = true;
 
-      // TODO: If/when required collect all non-relevant atoms
-      // (those that are not within a ghost_cell_layer_thickness
-      // for this MPI process energy computation)
-      // For now just add the number of molecules being thrown.
-      // TODO: Add another typedef for molecules index?
-      types::global_atom_index n_thrown_molecules=0;
+    // This MPI process also needs to know certain active ghost cells
+    // within a certain distance from locally owned cells.
+    // This MPI process will also keep copy of atoms associated to
+    // such active ghost cells.
+    // ghost_cells vector will contain all such active ghost cells.
+    // If the total number of MPI processes is just one,
+    // the size of ghost_cells vector is zero.
+    const
+    std::vector<typename types::MeshType<dim, spacedim>::active_cell_iterator>
+    ghost_cells =
+      GridTools::
+      compute_ghost_cell_layer_within_distance (mesh,
+                                                ghost_cell_layer_thickness);
 
-      for ( auto molecule : vector_molecules )
-        {
-          bool atom_associated_to_cell = false;
-          try
-            {
-              // Find the locally active cell of the provided mesh which
-              // surrounds the initial location of the molecule.
-              std::pair<
-              typename types::MeshType<dim, spacedim>::active_cell_iterator
-              ,
-              Point<dim>
-              >
-              my_pair = GridTools::find_active_cell_around_point (MappingQ1<dim,spacedim>(),
-                                                                  mesh,
-                                                                  molecule_initial_location(molecule),
-                                                                  locally_active_vertices);
+    // Loop through all the ghost cells computed above and
+    // mark (true) all the vertices of the locally owned and active
+    // ghost cells within ConfigureQC::ghost_cell_layer_thickness.
+    for (auto cell : ghost_cells)
+      for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
+        locally_active_vertices[cell->vertex_index(v)] = true;
 
-              // Since in locally_active_vertices all the vertices of
-              // the ghost cells are marked true, find_active_cell_around_point
-              // could take the liberty to find a cell that is not a ghost cell
-              // of a current MPI process but has one of it's vertices marked
-              // true.
-              // In such a case, we need to throw the atom and
-              // continue associating remaining atoms.
-              if (!my_pair.first->is_locally_owned() &&
-                  (std::find(ghost_cells.begin(), ghost_cells.end(), my_pair.first)==ghost_cells.end()))
-                {
-                  n_thrown_molecules++;
-                  continue;
-                }
+    // TODO: If/when required collect all non-relevant atoms
+    // (those that are not within a ghost_cell_layer_thickness
+    // for this MPI process energy computation)
+    // For now just add the number of molecules being thrown.
+    // TODO: Add another typedef for molecules index?
+    types::global_atom_index n_thrown_molecules=0;
 
-              Point<dim> reference_position_in_cell =
-                GeometryInfo<dim>::project_to_unit_cell(my_pair.second);
+    for ( auto molecule : vector_molecules )
+      {
+        bool atom_associated_to_cell = false;
+        try
+          {
+            // Find the locally active cell of the provided mesh which
+            // surrounds the initial location of the molecule.
+            std::pair<
+            typename types::MeshType<dim, spacedim>::active_cell_iterator
+            ,
+            Point<dim>
+            >
+            my_pair =
+              GridTools::
+              find_active_cell_around_point (MappingQ1<dim,spacedim>(),
+                                             mesh,
+                                             molecule_initial_location(molecule),
+                                             locally_active_vertices);
 
-              // Molecule is in spacedim-dimensional space but its location
-              // in the reference cell is in dim-dimensional space.
-              // Copy dim-dimensional Point into spacedim-dimensional Point.
-              for (int d = 0; d < dim; ++d)
-                molecule.position_inside_reference_cell[d] =
-                  reference_position_in_cell[d];
+            // Since in locally_active_vertices all the vertices of
+            // the ghost cells are marked true, find_active_cell_around_point
+            // could take the liberty to find a cell that is not a ghost cell
+            // of a current MPI process but has one of it's vertices marked
+            // true.
+            // In such a case, we need to throw the atom and
+            // continue associating remaining atoms.
+            if (!my_pair.first->is_locally_owned() &&
+                (std::find (ghost_cells.begin(),
+                            ghost_cells.end(),
+                            my_pair.first)==ghost_cells.end()))
+              {
+                n_thrown_molecules++;
+                continue;
+              }
 
-              for (int d = dim; d < spacedim; ++d)
-                molecule.position_inside_reference_cell[d] =
-                  std::numeric_limits<double>::signaling_NaN();
+            Point<dim> reference_position_in_cell =
+              GeometryInfo<dim>::project_to_unit_cell(my_pair.second);
 
-              cell_molecules.insert( std::make_pair( my_pair.first, molecule ));
-              atom_associated_to_cell = true;
-            }
-          catch (dealii::GridTools::ExcPointNotFound<dim> &)
-            {
-              // The atom is outside the cells that are relevant
-              // to this MPI process. Ensuring quiet execution.
-            }
+            // Molecule is in spacedim-dimensional space but its location
+            // in the reference cell is in dim-dimensional space.
+            // Copy dim-dimensional Point into spacedim-dimensional Point.
+            for (int d = 0; d < dim; ++d)
+              molecule.position_inside_reference_cell[d] =
+                reference_position_in_cell[d];
 
-          if ( !atom_associated_to_cell )
-            n_thrown_molecules++;
-        }
+            for (int d = dim; d < spacedim; ++d)
+              molecule.position_inside_reference_cell[d] =
+                std::numeric_limits<double>::signaling_NaN();
 
-      Assert (cell_molecules.size()+n_thrown_molecules==vector_molecules.size(),
-              ExcInternalError());
+            cell_molecules.insert( std::make_pair( my_pair.first, molecule ));
+            atom_associated_to_cell = true;
+          }
+        catch (dealii::GridTools::ExcPointNotFound<dim> &)
+          {
+            // The atom is outside the cells that are relevant
+            // to this MPI process. Ensuring quiet execution.
+          }
 
-      return cell_molecule_data;
-    }
+        if ( !atom_associated_to_cell )
+          n_thrown_molecules++;
+      }
+
+    Assert (cell_molecules.size()+n_thrown_molecules==vector_molecules.size(),
+            ExcInternalError());
+
+    return cell_molecule_data;
+  }
 
 
 
-    template <int dim, int atomicity, int spacedim>
-    IndexSet
-    extract_locally_relevant_dofs
-    (const dealii::DoFHandler<dim, spacedim>                          &dof_handler,
-     const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules)
-    {
-      // Prepare dof index set in this container.
-      IndexSet dof_set = dof_handler.locally_owned_dofs();
+  template <int dim, int atomicity, int spacedim>
+  IndexSet
+  extract_locally_relevant_dofs
+  (const dealii::DoFHandler<dim, spacedim>                          &dof_handler,
+   const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules)
+  {
+    // Prepare dof index set in this container.
+    IndexSet dof_set = dof_handler.locally_owned_dofs();
 
-      // Note: The logic here is similar to that of
-      // DoFTools::extract_locally_relevant_dofs().
-      std::vector<dealii::types::global_dof_index> dof_indices;
-      std::vector<dealii::types::global_dof_index> dofs_on_ghosts;
+    // Note: The logic here is similar to that of
+    // DoFTools::extract_locally_relevant_dofs().
+    std::vector<dealii::types::global_dof_index> dof_indices;
+    std::vector<dealii::types::global_dof_index> dofs_on_ghosts;
 
-      // Loop over unique locally relevant cells.
-      for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-           unique_key  = cell_molecules.cbegin();
-           unique_key != cell_molecules.cend();
-           unique_key  = cell_molecules.upper_bound(unique_key->first))
-        {
-          const auto &cell = unique_key->first;
+    // Loop over unique locally relevant cells.
+    for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+         unique_key  = cell_molecules.cbegin();
+         unique_key != cell_molecules.cend();
+         unique_key  = cell_molecules.upper_bound(unique_key->first))
+      {
+        const auto &cell = unique_key->first;
 
-          dof_indices.resize(cell->get_fe().dofs_per_cell);
-          cell->get_dof_indices(dof_indices);
-          for (unsigned int i=0; i<dof_indices.size(); ++i)
-            if (!dof_set.is_element(dof_indices[i]))
-              dofs_on_ghosts.push_back(dof_indices[i]);
-        }
+        dof_indices.resize(cell->get_fe().dofs_per_cell);
+        cell->get_dof_indices(dof_indices);
+        for (unsigned int i=0; i<dof_indices.size(); ++i)
+          if (!dof_set.is_element(dof_indices[i]))
+            dofs_on_ghosts.push_back(dof_indices[i]);
+      }
 
-      // Sort, fill into index set and compress out duplicates.
-      std::sort(dofs_on_ghosts.begin(), dofs_on_ghosts.end());
-      dof_set.add_indices (dofs_on_ghosts.begin(),
-                           std::unique (dofs_on_ghosts.begin(),
-                                        dofs_on_ghosts.end()));
-      dof_set.compress();
+    // Sort, fill into index set and compress out duplicates.
+    std::sort(dofs_on_ghosts.begin(), dofs_on_ghosts.end());
+    dof_set.add_indices (dofs_on_ghosts.begin(),
+                         std::unique (dofs_on_ghosts.begin(),
+                                      dofs_on_ghosts.end()));
+    dof_set.compress();
 
-      return dof_set;
-    }
+    return dof_set;
+  }
 
 
 #define SINGLE_CELL_MOLECULE_TOOLS_INSTANTIATION(DIM, ATOMICITY, SPACEDIM) \
@@ -308,15 +315,15 @@ namespace dealiiqc
               SINGLE_CELL_MOLECULE_TOOLS_INSTANTIATION, \
               BOOST_PP_TUPLE_EAT(3)) X
 
-    // MoleculeHandler class Instantiations.
-    INSTANTIATE_CLASS_WITH_DIM_ATOMICITY_AND_SPACEDIM(CELL_MOLECULE_TOOLS)
+  // MoleculeHandler class Instantiations.
+  INSTANTIATE_CLASS_WITH_DIM_ATOMICITY_AND_SPACEDIM(CELL_MOLECULE_TOOLS)
 
 #undef SINGLE_CELL_MOLECULE_TOOLS_INSTANTIATION
 #undef CELL_MOLECULE_TOOLS
 
 
-  } // namespace CellMoleculeTools
+} // namespace CellMoleculeTools
 
 
-} // namespace dealiiqc
+DEAL_II_QC_NAMESPACE_CLOSE
 

--- a/source/atom/molecule_handler.cc
+++ b/source/atom/molecule_handler.cc
@@ -4,212 +4,211 @@
 #include <deal.II-qc/atom/molecule_handler.h>
 
 
-namespace dealiiqc
+DEAL_II_QC_NAMESPACE_OPEN
+
+
+template<int dim, int atomicity, int spacedim>
+MoleculeHandler<dim, atomicity, spacedim>::
+MoleculeHandler (const ConfigureQC &configure_qc)
+  :
+  configure_qc(configure_qc)
+{}
+
+
+
+template<int dim, int atomicity, int spacedim>
+types::CellMoleculeNeighborLists<dim, atomicity, spacedim>
+MoleculeHandler<dim, atomicity, spacedim>::
+get_neighbor_lists
+(const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules) const
 {
+  // Check whether cell_energy_molecules is empty; throw error if it is.
+  Assert (cell_energy_molecules.size(),
+          ExcInternalError());
 
+  types::CellMoleculeNeighborLists<dim, atomicity, spacedim> neighbor_lists;
 
-  template<int dim, int atomicity, int spacedim>
-  MoleculeHandler<dim, atomicity, spacedim>::
-  MoleculeHandler (const ConfigureQC &configure_qc)
-    :
-    configure_qc(configure_qc)
-  {}
+  // cell_neighbor_lists contains all the pairs of cell
+  // whose molecules interact with each other.
+  std::list< std::pair<
+  types::CellIteratorType<dim, spacedim>
+  ,
+  types::CellIteratorType<dim, spacedim> >> cell_neighbor_lists;
 
+  const double cutoff_radius  = configure_qc.get_maximum_cutoff_radius();
+  const double squared_cutoff_radius  =
+    dealii::Utilities::fixed_power<2>(cutoff_radius);
 
-
-  template<int dim, int atomicity, int spacedim>
-  types::CellMoleculeNeighborLists<dim, atomicity, spacedim>
-  MoleculeHandler<dim, atomicity, spacedim>::
-  get_neighbor_lists
-  (const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules) const
-  {
-    // Check whether cell_energy_molecules is empty; throw error if it is.
-    Assert (cell_energy_molecules.size(),
-            ExcInternalError());
-
-    types::CellMoleculeNeighborLists<dim, atomicity, spacedim> neighbor_lists;
-
-    // cell_neighbor_lists contains all the pairs of cell
-    // whose molecules interact with each other.
-    std::list< std::pair<
-    types::CellIteratorType<dim, spacedim>
-    ,
-    types::CellIteratorType<dim, spacedim> >> cell_neighbor_lists;
-
-    const double cutoff_radius  = configure_qc.get_maximum_cutoff_radius();
-    const double squared_cutoff_radius  =
-      dealii::Utilities::fixed_power<2>(cutoff_radius);
-
-    // For each locally owned cell, identify all the cells
-    // whose associated molecules may interact. At this point we do not
-    // check if there are indeed some interacting molecules,
-    // i.e. those within the cut-off radius. This is done to speedup
-    // building of the neighbor list.
-    // TODO: this approach strictly holds in the reference
-    // (undeformed) configuration only.
-    // It may still be OK for small deformations,
-    // but for large deformations we may need to
-    // use something like MappingQEulerian to work
-    // with the deformed mesh.
-    // TODO: optimize loop over unique keys
-    // ( mulitmap::upper_bound()'s complexity is O(nlogn) )
-    for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-         unique_I  = cell_energy_molecules.cbegin();
-         unique_I != cell_energy_molecules.cend();
-         unique_I  = cell_energy_molecules.upper_bound(unique_I->first))
-      // Only locally owned cells have cell neighbors
-      if (unique_I->first->is_locally_owned())
-        {
-          types::ConstCellIteratorType<dim, spacedim> cell_I = unique_I->first;
-
-          // Get center and the radius of the enclosing ball of cell_I
-          const auto enclosing_ball_I = cell_I->enclosing_ball();
-
-          for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-               unique_J  = cell_energy_molecules.cbegin();
-               unique_J != cell_energy_molecules.cend();
-               unique_J  = cell_energy_molecules.upper_bound(unique_J->first))
-            {
-              types::ConstCellIteratorType<dim, spacedim>
-              cell_J = unique_J->first;
-
-              // Get center and the radius of the enclosing ball of cell_I
-              const auto enclosing_ball_J = cell_J->enclosing_ball();
-
-              // If the shortest distance between the enclosing balls of
-              // cell_I and cell_J is less than cutoff_radius, then the
-              // cell pair is in the cell_neighbor_lists.
-              if (enclosing_ball_I.first.distance_square(enclosing_ball_J.first)
-                  < dealii::Utilities::fixed_power<2>(cutoff_radius +
-                                                      enclosing_ball_I.second +
-                                                      enclosing_ball_J.second) )
-                cell_neighbor_lists.push_back( std::make_pair(cell_I, cell_J) );
-            }
-        }
-
-    for (const auto &cell_pair_IJ : cell_neighbor_lists)
+  // For each locally owned cell, identify all the cells
+  // whose associated molecules may interact. At this point we do not
+  // check if there are indeed some interacting molecules,
+  // i.e. those within the cut-off radius. This is done to speedup
+  // building of the neighbor list.
+  // TODO: this approach strictly holds in the reference
+  // (undeformed) configuration only.
+  // It may still be OK for small deformations,
+  // but for large deformations we may need to
+  // use something like MappingQEulerian to work
+  // with the deformed mesh.
+  // TODO: optimize loop over unique keys
+  // ( mulitmap::upper_bound()'s complexity is O(nlogn) )
+  for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+       unique_I  = cell_energy_molecules.cbegin();
+       unique_I != cell_energy_molecules.cend();
+       unique_I  = cell_energy_molecules.upper_bound(unique_I->first))
+    // Only locally owned cells have cell neighbors
+    if (unique_I->first->is_locally_owned())
       {
-        types::ConstCellIteratorType<dim, spacedim> cell_I = cell_pair_IJ.first;
-        types::ConstCellIteratorType<dim, spacedim> cell_J = cell_pair_IJ.second;
+        types::ConstCellIteratorType<dim, spacedim> cell_I = unique_I->first;
 
-        std::pair<
-        types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-        ,
-        types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-        >
-        range_of_cell_I = cell_energy_molecules.equal_range(cell_I),
-        range_of_cell_J = cell_energy_molecules.equal_range(cell_J);
+        // Get center and the radius of the enclosing ball of cell_I
+        const auto enclosing_ball_I = cell_I->enclosing_ball();
 
-        // For each molecule associated to locally owned cell_I
         for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-             cell_molecule_I  = range_of_cell_I.first;
-             cell_molecule_I != range_of_cell_I.second;
-             cell_molecule_I++)
+             unique_J  = cell_energy_molecules.cbegin();
+             unique_J != cell_energy_molecules.cend();
+             unique_J  = cell_energy_molecules.upper_bound(unique_J->first))
           {
+            types::ConstCellIteratorType<dim, spacedim>
+            cell_J = unique_J->first;
 
-            const Molecule<spacedim, atomicity>
-            &molecule_I = cell_molecule_I->second;
+            // Get center and the radius of the enclosing ball of cell_I
+            const auto enclosing_ball_J = cell_J->enclosing_ball();
 
-            // Check if the molecule_I is cluster molecule,
-            // only cluster molecules get to be in neighbor lists.
-            if (molecule_I.cluster_weight != 0)
-
-              for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
-                   cell_molecule_J  = range_of_cell_J.first;
-                   cell_molecule_J != range_of_cell_J.second;
-                   cell_molecule_J++ )
-                {
-
-                  const Molecule<spacedim, atomicity>
-                  &molecule_J = cell_molecule_J->second;
-
-                  // Check whether molecule_J is cluster molecule
-                  const bool
-                  molecule_J_is_cluster_molecule =
-                      (molecule_J.cluster_weight != 0);
-
-                  // If molecule_J is also a cluster molecule,
-                  // then molecule_J could be only added to molecule_I's neighbor
-                  // list when molecule_I's index is greater than that of
-                  // molecule_J. This ensures that there is no double counting of
-                  // energy contribution thorugh both the cluster molecules:
-                  // molecule_I and molecule_J.
-                  // OR
-                  // If molecule_J is not cluster molecule,
-                  // then molecule_J could be added to (cluster) molecule_I's
-                  // neighbor list.
-                  if ( (molecule_J_is_cluster_molecule &&
-                        (molecule_I.global_index > molecule_J.global_index))
-                       ||
-                       !molecule_J_is_cluster_molecule )
-
-                    // Check distances between all atoms of one molecule to
-                    // all atoms of the other molecule. If any two atoms of
-                    // different molecules interact, then the molecules are in
-                    // neighbor lists.
-                    if (least_distance_squared(molecule_I, molecule_J)
-                        < squared_cutoff_radius)
-                      neighbor_lists.insert
-                      (
-                        std::make_pair (cell_pair_IJ,
-                                        std::make_pair (cell_molecule_I,
-                                                        cell_molecule_J))
-                      );
-                }
+            // If the shortest distance between the enclosing balls of
+            // cell_I and cell_J is less than cutoff_radius, then the
+            // cell pair is in the cell_neighbor_lists.
+            if (enclosing_ball_I.first.distance_square(enclosing_ball_J.first)
+                < dealii::Utilities::fixed_power<2>(cutoff_radius +
+                                                    enclosing_ball_I.second +
+                                                    enclosing_ball_J.second) )
+              cell_neighbor_lists.push_back( std::make_pair(cell_I, cell_J) );
           }
-
       }
 
-#ifdef DEBUG
-    // For large deformations the cells might
-    // distort leading to incorrect neighbor_list
-    // using the above hierarchical procedure of
-    // updating neighbor lists.
-    // In debug mode, check if the number
-    // of interactions is the same as computed
-    // by the following.
-    unsigned int total_number_of_interactions = 0;
+  for (const auto &cell_pair_IJ : cell_neighbor_lists)
+    {
+      types::ConstCellIteratorType<dim, spacedim> cell_I = cell_pair_IJ.first;
+      types::ConstCellIteratorType<dim, spacedim> cell_J = cell_pair_IJ.second;
 
-    // loop over all atoms
-    //   if locally owned cell
-    //     loop over all atoms
-    //       if within distance
-    //         total_number_of_interactions++;
-    for (const auto &cell_molecule_I : cell_energy_molecules)
-      if (cell_molecule_I.first->is_locally_owned())
+      std::pair<
+      types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+      ,
+      types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+      >
+      range_of_cell_I = cell_energy_molecules.equal_range(cell_I),
+      range_of_cell_J = cell_energy_molecules.equal_range(cell_J);
+
+      // For each molecule associated to locally owned cell_I
+      for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+           cell_molecule_I  = range_of_cell_I.first;
+           cell_molecule_I != range_of_cell_I.second;
+           cell_molecule_I++)
         {
+
           const Molecule<spacedim, atomicity>
-          &molecule_I = cell_molecule_I.second;
+          &molecule_I = cell_molecule_I->second;
 
           // Check if the molecule_I is cluster molecule,
           // only cluster molecules get to be in neighbor lists.
           if (molecule_I.cluster_weight != 0)
-            for (const auto &cell_molecule_J : cell_energy_molecules)
+
+            for (types::CellMoleculeConstIteratorType<dim, atomicity, spacedim>
+                 cell_molecule_J  = range_of_cell_J.first;
+                 cell_molecule_J != range_of_cell_J.second;
+                 cell_molecule_J++ )
               {
+
                 const Molecule<spacedim, atomicity>
-                &molecule_J = cell_molecule_J.second;
+                &molecule_J = cell_molecule_J->second;
 
                 // Check whether molecule_J is cluster molecule
                 const bool
                 molecule_J_is_cluster_molecule =
-                    (molecule_J.cluster_weight != 0);
+                  (molecule_J.cluster_weight != 0);
 
+                // If molecule_J is also a cluster molecule,
+                // then molecule_J could be only added to molecule_I's neighbor
+                // list when molecule_I's index is greater than that of
+                // molecule_J. This ensures that there is no double counting of
+                // energy contribution thorugh both the cluster molecules:
+                // molecule_I and molecule_J.
+                // OR
+                // If molecule_J is not cluster molecule,
+                // then molecule_J could be added to (cluster) molecule_I's
+                // neighbor list.
                 if ( (molecule_J_is_cluster_molecule &&
                       (molecule_I.global_index > molecule_J.global_index))
                      ||
                      !molecule_J_is_cluster_molecule )
+
+                  // Check distances between all atoms of one molecule to
+                  // all atoms of the other molecule. If any two atoms of
+                  // different molecules interact, then the molecules are in
+                  // neighbor lists.
                   if (least_distance_squared(molecule_I, molecule_J)
                       < squared_cutoff_radius)
-                    total_number_of_interactions++;
+                    neighbor_lists.insert
+                    (
+                      std::make_pair (cell_pair_IJ,
+                                      std::make_pair (cell_molecule_I,
+                                                      cell_molecule_J))
+                    );
               }
         }
-    Assert (total_number_of_interactions == neighbor_lists.size(),
-            ExcMessage("Some of the interactions are not accounted "
-                       "while updating neighbor lists"));
+
+    }
+
+#ifdef DEBUG
+  // For large deformations the cells might
+  // distort leading to incorrect neighbor_list
+  // using the above hierarchical procedure of
+  // updating neighbor lists.
+  // In debug mode, check if the number
+  // of interactions is the same as computed
+  // by the following.
+  unsigned int total_number_of_interactions = 0;
+
+  // loop over all atoms
+  //   if locally owned cell
+  //     loop over all atoms
+  //       if within distance
+  //         total_number_of_interactions++;
+  for (const auto &cell_molecule_I : cell_energy_molecules)
+    if (cell_molecule_I.first->is_locally_owned())
+      {
+        const Molecule<spacedim, atomicity>
+        &molecule_I = cell_molecule_I.second;
+
+        // Check if the molecule_I is cluster molecule,
+        // only cluster molecules get to be in neighbor lists.
+        if (molecule_I.cluster_weight != 0)
+          for (const auto &cell_molecule_J : cell_energy_molecules)
+            {
+              const Molecule<spacedim, atomicity>
+              &molecule_J = cell_molecule_J.second;
+
+              // Check whether molecule_J is cluster molecule
+              const bool
+              molecule_J_is_cluster_molecule =
+                (molecule_J.cluster_weight != 0);
+
+              if ( (molecule_J_is_cluster_molecule &&
+                    (molecule_I.global_index > molecule_J.global_index))
+                   ||
+                   !molecule_J_is_cluster_molecule )
+                if (least_distance_squared(molecule_I, molecule_J)
+                    < squared_cutoff_radius)
+                  total_number_of_interactions++;
+            }
+      }
+  Assert (total_number_of_interactions == neighbor_lists.size(),
+          ExcMessage("Some of the interactions are not accounted "
+                     "while updating neighbor lists"));
 #endif
 
-    return neighbor_lists;
-  }
+  return neighbor_lists;
+}
 
 
 
@@ -221,11 +220,11 @@ namespace dealiiqc
               SINGLE_MOLECULE_HANDLER_INSTANTIATION, \
               BOOST_PP_TUPLE_EAT(3)) X               \
    
-  // MoleculeHandler class Instantiations.
-  INSTANTIATE_CLASS_WITH_DIM_ATOMICITY_AND_SPACEDIM(MOLECULE_HANDLER)
+// MoleculeHandler class Instantiations.
+INSTANTIATE_CLASS_WITH_DIM_ATOMICITY_AND_SPACEDIM(MOLECULE_HANDLER)
 
 #undef SINGLE_MOLECULE_HANDLER_INSTANTIATION
 #undef MOLECULE_HANDLER
 
 
-} // dealiiqc namespace
+DEAL_II_QC_NAMESPACE_CLOSE

--- a/source/atom/parse_atom_data.cc
+++ b/source/atom/parse_atom_data.cc
@@ -3,385 +3,390 @@
 
 #include <deal.II-qc/atom/parse_atom_data.h>
 
-namespace dealiiqc
+
+DEAL_II_QC_NAMESPACE_OPEN
+
+
+using namespace dealii;
+
+template<int spacedim, int atomicity>
+ParseAtomData<spacedim, atomicity>::ParseAtomData()
+  :
+  n_atoms(0),
+  n_atom_types(0),
+  line_no(0)
+{}
+
+template<int spacedim, int atomicity>
+void
+ParseAtomData<spacedim, atomicity>::parse (std::istream                               &is,
+                                           std::vector<Molecule<spacedim, atomicity>> &molecules,
+                                           std::vector<types::charge>                 &charges,
+                                           std::vector<double>                        &masses)
 {
-  using namespace dealii;
+  AssertThrow (is, ExcIO());
 
-  template<int spacedim, int atomicity>
-  ParseAtomData<spacedim, atomicity>::ParseAtomData()
-    :
-    n_atoms(0),
-    n_atom_types(0),
-    line_no(0)
-  {}
+  std::string line;
 
-  template<int spacedim, int atomicity>
-  void
-  ParseAtomData<spacedim, atomicity>::parse (std::istream                               &is,
-                                             std::vector<Molecule<spacedim, atomicity>> &molecules,
-                                             std::vector<types::charge>                 &charges,
-                                             std::vector<double>                        &masses)
-  {
-    AssertThrow (is, ExcIO());
+  // Some temporary variables
+  unsigned int nbonds = 0;
+  unsigned int nangles = 0;
+  unsigned int ndihedrals = 0;
+  unsigned int nimpropers = 0;
 
-    std::string line;
+  // Dimensions of the simulation box
+  double xlo(0.),xhi(0.),
+         ylo(0.),yhi(0.),
+         zlo(0.),zhi(0.);
 
-    // Some temporary variables
-    unsigned int nbonds = 0;
-    unsigned int nangles = 0;
-    unsigned int ndihedrals = 0;
-    unsigned int nimpropers = 0;
+  // Tilts of the simulation box
+  double xy(0.),xz(0.),yz(0.);
 
-    // Dimensions of the simulation box
-    double xlo(0.),xhi(0.),
-           ylo(0.),yhi(0.),
-           zlo(0.),zhi(0.);
+  // Read comment line (first line)
+  line_no++;
+  if (!std::getline(is,line))
+    Assert( false, ExcReadFailed(line_no));
 
-    // Tilts of the simulation box
-    double xy(0.),xz(0.),yz(0.);
-
-    // Read comment line (first line)
-    line_no++;
-    if (!std::getline(is,line))
-      Assert( false, ExcReadFailed(line_no));
-
-    // Read main header declarations
-    while ( std::getline(is,line) )
-      {
-        line_no++;
-
-        // strip all the comments and all white characters
-        line = strip(line);
-
-        // Skip empty lines
-        if ( line.size()==0)
-          continue;
-
-        // Read and store n_atoms, nbonds, ...
-        if (line.find("atoms") != std::string::npos)
-          {
-            unsigned long long int n_atoms_tmp;
-            if (sscanf(line.c_str(), "%llu", &n_atoms_tmp) != 1)
-              AssertThrow( false, ExcInvalidValue(line_no,"atoms"));
-            if ( n_atoms_tmp <= UINT_MAX )
-              n_atoms = static_cast<types::global_atom_index>(n_atoms_tmp);
-            else
-              AssertThrow( false,
-                           ExcMessage("The number of atoms specified "
-                                      "is more than what `typedefs::global_atom_index` can work with "
-                                      "try building deal.II with 64bit index space"));
-            Assert (n_atoms % atomicity == 0,
-                    ExcMessage("The total number of atoms provided in the "
-                               "atom data do not form integer molecules. "));
-          }
-        else if (line.find("bonds") != std::string::npos)
-          {
-            if (sscanf(line.c_str(), "%u", &nbonds) != 1)
-              Assert( false, ExcInvalidValue(line_no,"bonds"));
-            Assert( nbonds==0, ExcIrrelevant(line_no));
-          }
-        else if (line.find("angles") != std::string::npos)
-          {
-            if (sscanf(line.c_str(), "%u", &nangles) != 1)
-              Assert( false, ExcInvalidValue(line_no,"angles"));
-            Assert( nangles==0, ExcIrrelevant(line_no));
-          }
-        else if (line.find("dihedrals") != std::string::npos)
-          {
-            if (sscanf(line.c_str(), "%u", &ndihedrals) != 1)
-              Assert( false, ExcInvalidValue(line_no,"dihedrals"));
-            Assert( ndihedrals==0, ExcIrrelevant(line_no));
-          }
-        else if (line.find("impropers") != std::string::npos)
-          {
-            if (sscanf(line.c_str(), "%u", &nimpropers) != 1)
-              Assert( false, ExcInvalidValue(line_no,"impropers"));
-            Assert( nimpropers==0, ExcIrrelevant(line_no));
-          }
-        else if (line.find("atom types") != std::string::npos)
-          {
-            if (sscanf(line.c_str(), "%zu", &n_atom_types) != 1)
-              Assert( false , ExcInvalidValue(line_no,"number of atom types"));
-          }
-        else if (line.find("xlo xhi") != std::string::npos)
-          {
-            if (sscanf(line.c_str(), "%lf %lf", &xlo, &xhi) != 2)
-              Assert( false, ExcInvalidValue(line_no,"simulation box dimensions"));
-          }
-        else if (line.find("ylo yhi") != std::string::npos)
-          {
-            if (sscanf(line.c_str(), "%lf %lf", &ylo, &yhi) != 2)
-              Assert( false, ExcInvalidValue(line_no,"simulation box dimensions"));
-          }
-        else if (line.find("zlo zhi") != std::string::npos)
-          {
-            if (sscanf(line.c_str(), "%lf %lf", &zlo, &zhi) != 2)
-              Assert( false, ExcInvalidValue(line_no,"simulation box dimensions"));
-          }
-        else if (line.find("xy xz yz") != std::string::npos)
-          {
-            if (sscanf(line.c_str(), "%lf %lf %lf", &xy, &xz, &yz) != 3)
-              Assert( false, ExcInvalidValue(line_no,"simulation box tilts"));
-            Assert((((xy==xz)==yz)==0), ExcIrrelevant(line_no));
-          }
-        else break;
-      }
-
-    Assert( xhi >= xlo || yhi >= ylo || zhi >= zlo,
-            ExcMessage("Invalid simulation box size"))
-    // TODO: Extra Asserts with dim and simulation box dimensions
-    // TODO: copy simulation box dimensions, check for inconsistent mesh?
-
-    molecules.resize(n_atoms/atomicity);
-    charges.resize(n_atom_types);
-    masses.resize(n_atom_types, 0.);
-
-    // line has been read by previous while loop but wasn't parsed for keyword sections
-    --line_no;
-    do
-      {
-        // Read sections with keyword headings (Atoms, Masses)
-        // For now ignoring other keyword headings // TODO?
-        if ( dealii::Utilities::match_at_string_start(line, "Masses") )
-          {
-            // parse_masses is allowed to be executed multiple times.
-            parse_masses(is, masses);
-          }
-        else if ( dealii::Utilities::match_at_string_start(line,"Atoms"))
-          {
-            // parse_atoms is allowed to be executed multiple times.
-            parse_atoms(is, molecules, charges);
-          }
-        ++line_no;
-      }
-    while ( std::getline(is,line) );
-
-    return;
-  }
-
-
-
-  template<int spacedim, int atomicity>
-  void
-  ParseAtomData<spacedim, atomicity>::parse_atoms (std::istream                               &is,
-                                                   std::vector<Molecule<spacedim, atomicity>> &molecules,
-                                                   std::vector<types::charge>                 &charges)
-  {
-    std::string line;
-
-    // Atom counting starts from 1 in the atom data and
-    // we count from 0.
-    unsigned long long int  i_atom_index;
-
-    // Molecule count begins from 1 in the atom data and
-    // we count from with 0.
-    // i_molecule = i_molecule_index-1
-    unsigned long long int i_molecule_index;
-    types::global_atom_index i_molecule;
-
-    // i_atom_type = i_atom_char_type -1
-    // atom type count begins from 1 in atom data and
-    // we count from 0.
-    unsigned char i_atom_char_type;
-    types::atom_type i_atom_type;
-
-    // Temporary variable to count number of atom types.
-    std::vector<types::atom_type> unique_types;
-
-    // Charges read for each atom.
-    double i_q;
-
-    // Prepare position of the atom in this container.
-    std::array<double, 3> position;
-
-    // Since we cannot push_back atoms into molecules, we need to keep track
-    // of the number of atoms already inserted into molecules.
-    std::vector<int> n_atoms_added_per_molecule(n_atoms/atomicity, 0);
-
-    // Prepare an atom in this container for each line read.
-    Atom<spacedim> temporary_atom;
-
-    // Store atom attributes and positions.
-    types::global_atom_index i=0;
-    while ( std::getline(is,line) && i < n_atoms)
-      {
-        ++line_no;
-        line = strip(line);
-        if ( line.size()==0)
-          continue;
-
-        // Not reading molecular_id
-        if (sscanf(line.c_str(), "%llu  %llu " UC_SCANF_STR " %lf %lf %lf %lf",
-                   &i_atom_index,
-                   &i_molecule_index,
-                   &i_atom_char_type,
-                   &i_q,
-                   &position[0],
-                   &position[1],
-                   &position[2]) !=7)
-          AssertThrow (false,
-                       ExcInvalidValue( line_no,
-                                        "atom attributes under Atom keyword section"));
-
-        Assert (i_atom_index<=n_atoms && i_atom_index>0,
-                ExcInvalidValue( line_no,
-                                 "atom index (> number of atoms or <=0"));
-
-        temporary_atom.global_index =
-          static_cast<types::global_atom_index>(i_atom_index) - 1;
-
-        i_atom_type = static_cast<types::atom_type> (i_atom_char_type) - 1;
-        temporary_atom.type = i_atom_type;
-
-        Assert (i_atom_type >= 0 && i_atom_type < 256,
-                ExcInvalidValue(line_no, "atom type attribute"));
-
-        // TODO: 1 and 2 dim cases could be potentially incorrect
-        // Possible way to correct this is to ask user axes dimensionality
-        Assert (spacedim <=3, ExcNotImplemented());
-
-        for (int d = 0; d < spacedim; ++d)
-          temporary_atom.position[d] = position[d];
-
-        temporary_atom.initial_position = temporary_atom.position;
-
-        //---Atom attributes are prepared for temporary_atom.
-
-        //---Prepare charges.
-
-        if (std::find(unique_types.begin(), unique_types.end(), i_atom_type) == unique_types.end())
-          {
-            unique_types.push_back(i_atom_type);
-            charges[i_atom_type] = static_cast<types::charge>(i_q);
-          }
-        else
-          Assert (charges[i_atom_type]==static_cast<types::charge>(i_q),
-                  ExcInvalidValue(line_no, "charge attribute"));
-
-        //---Ready to insert atom into molecule.
-
-        i_molecule = static_cast<types::global_atom_index>(i_molecule_index) - 1;
-
-        // Set molecule global id
-        molecules[i_molecule].global_index = i_molecule;
-
-        // Add atom to the molecule.
-        molecules[i_molecule].atoms[n_atoms_added_per_molecule[i_molecule]] =
-          temporary_atom;
-
-        // Increment the number of atoms added to ith molecule.
-        n_atoms_added_per_molecule[i_molecule]++;
-
-        // Set some member variables of i_molecule to invalid values as
-        // the current class cannot initialize to correct values.
-        molecules[i_molecule].local_index    = dealii::numbers::invalid_unsigned_int;
-        molecules[i_molecule].cluster_weight = numbers::invalid_cluster_weight;
-
-        ++i;
-      }
-
-    Assert (unique_types.size()==n_atom_types,
-            ExcInternalError());
-
-    Assert (i==n_atoms,
-            ExcMessage("The number of atoms do not match the number of entries "
-                       "under Atoms keyword section"));
-
-    //---At this point atoms in molecules are not sorted according to their
-    //   stamps.
-
-    //---For now it is not possible to ensure correct order of stamps for
-    //   repeated atom types.
-    //   Example: A2B molecule could have two possible stamp orderings.
-    //
-    //   case 1:  0 1 2         ----------> stamp order
-    //            0 0 1         ----------> type order
-    //
-    //   case 2:  1 0 2         ----------> stamp order
-    //            0 0 1         ----------> type order
-
-    // Making a lambda for atom type comparision
-    auto comparator_atom_type = [] (const decltype(temporary_atom) &a,
-                                    const decltype(temporary_atom) &b)
+  // Read main header declarations
+  while ( std::getline(is,line) )
     {
-      return a.type < b.type;
-    };
+      line_no++;
 
-    for (auto &molecule : molecules)
-      {
-        std::sort (molecule.atoms.begin(),
-                   molecule.atoms.end(),
-                   comparator_atom_type);
-      }
+      // strip all the comments and all white characters
+      line = strip(line);
 
-    return;
-  }
+      // Skip empty lines
+      if ( line.size()==0)
+        continue;
+
+      // Read and store n_atoms, nbonds, ...
+      if (line.find("atoms") != std::string::npos)
+        {
+          unsigned long long int n_atoms_tmp;
+          if (sscanf(line.c_str(), "%llu", &n_atoms_tmp) != 1)
+            AssertThrow( false, ExcInvalidValue(line_no,"atoms"));
+          if ( n_atoms_tmp <= UINT_MAX )
+            n_atoms = static_cast<types::global_atom_index>(n_atoms_tmp);
+          else
+            AssertThrow( false,
+                         ExcMessage("The number of atoms specified "
+                                    "is more than what "
+                                    "`typedefs::global_atom_index` can work"
+                                    " with try building deal.II with 64bit"
+                                    " index space"));
+          Assert (n_atoms % atomicity == 0,
+                  ExcMessage("The total number of atoms provided in the "
+                             "atom data do not form integer molecules. "));
+        }
+      else if (line.find("bonds") != std::string::npos)
+        {
+          if (sscanf(line.c_str(), "%u", &nbonds) != 1)
+            Assert( false, ExcInvalidValue(line_no,"bonds"));
+          Assert( nbonds==0, ExcIrrelevant(line_no));
+        }
+      else if (line.find("angles") != std::string::npos)
+        {
+          if (sscanf(line.c_str(), "%u", &nangles) != 1)
+            Assert( false, ExcInvalidValue(line_no,"angles"));
+          Assert( nangles==0, ExcIrrelevant(line_no));
+        }
+      else if (line.find("dihedrals") != std::string::npos)
+        {
+          if (sscanf(line.c_str(), "%u", &ndihedrals) != 1)
+            Assert( false, ExcInvalidValue(line_no,"dihedrals"));
+          Assert( ndihedrals==0, ExcIrrelevant(line_no));
+        }
+      else if (line.find("impropers") != std::string::npos)
+        {
+          if (sscanf(line.c_str(), "%u", &nimpropers) != 1)
+            Assert( false, ExcInvalidValue(line_no,"impropers"));
+          Assert( nimpropers==0, ExcIrrelevant(line_no));
+        }
+      else if (line.find("atom types") != std::string::npos)
+        {
+          if (sscanf(line.c_str(), "%zu", &n_atom_types) != 1)
+            Assert( false , ExcInvalidValue(line_no,"number of atom types"));
+        }
+      else if (line.find("xlo xhi") != std::string::npos)
+        {
+          if (sscanf(line.c_str(), "%lf %lf", &xlo, &xhi) != 2)
+            Assert( false, ExcInvalidValue(line_no,"simulation box dimensions"));
+        }
+      else if (line.find("ylo yhi") != std::string::npos)
+        {
+          if (sscanf(line.c_str(), "%lf %lf", &ylo, &yhi) != 2)
+            Assert( false, ExcInvalidValue(line_no,"simulation box dimensions"));
+        }
+      else if (line.find("zlo zhi") != std::string::npos)
+        {
+          if (sscanf(line.c_str(), "%lf %lf", &zlo, &zhi) != 2)
+            Assert( false, ExcInvalidValue(line_no,"simulation box dimensions"));
+        }
+      else if (line.find("xy xz yz") != std::string::npos)
+        {
+          if (sscanf(line.c_str(), "%lf %lf %lf", &xy, &xz, &yz) != 3)
+            Assert( false, ExcInvalidValue(line_no,"simulation box tilts"));
+          Assert((((xy==xz)==yz)==0), ExcIrrelevant(line_no));
+        }
+      else break;
+    }
+
+  Assert( xhi >= xlo || yhi >= ylo || zhi >= zlo,
+          ExcMessage("Invalid simulation box size"))
+  // TODO: Extra Asserts with dim and simulation box dimensions
+  // TODO: copy simulation box dimensions, check for inconsistent mesh?
+
+  molecules.resize(n_atoms/atomicity);
+  charges.resize(n_atom_types);
+  masses.resize(n_atom_types, 0.);
+
+  // line has been read by previous while loop but wasn't parsed for keyword sections
+  --line_no;
+  do
+    {
+      // Read sections with keyword headings (Atoms, Masses)
+      // For now ignoring other keyword headings // TODO?
+      if ( dealii::Utilities::match_at_string_start(line, "Masses") )
+        {
+          // parse_masses is allowed to be executed multiple times.
+          parse_masses(is, masses);
+        }
+      else if ( dealii::Utilities::match_at_string_start(line,"Atoms"))
+        {
+          // parse_atoms is allowed to be executed multiple times.
+          parse_atoms(is, molecules, charges);
+        }
+      ++line_no;
+    }
+  while ( std::getline(is,line) );
+
+  return;
+}
 
 
 
-  template<int spacedim, int atomicity>
-  void
-  ParseAtomData<spacedim, atomicity>::parse_masses (std::istream        &is,
-                                                    std::vector<double> &masses)
+template<int spacedim, int atomicity>
+void
+ParseAtomData<spacedim, atomicity>::parse_atoms (std::istream                               &is,
+                                                 std::vector<Molecule<spacedim, atomicity>> &molecules,
+                                                 std::vector<types::charge>                 &charges)
+{
+  std::string line;
+
+  // Atom counting starts from 1 in the atom data and
+  // we count from 0.
+  unsigned long long int  i_atom_index;
+
+  // Molecule count begins from 1 in the atom data and
+  // we count from with 0.
+  // i_molecule = i_molecule_index-1
+  unsigned long long int i_molecule_index;
+  types::global_atom_index i_molecule;
+
+  // i_atom_type = i_atom_char_type -1
+  // atom type count begins from 1 in atom data and
+  // we count from 0.
+  unsigned char i_atom_char_type;
+  types::atom_type i_atom_type;
+
+  // Temporary variable to count number of atom types.
+  std::vector<types::atom_type> unique_types;
+
+  // Charges read for each atom.
+  double i_q;
+
+  // Prepare position of the atom in this container.
+  std::array<double, 3> position;
+
+  // Since we cannot push_back atoms into molecules, we need to keep track
+  // of the number of atoms already inserted into molecules.
+  std::vector<int> n_atoms_added_per_molecule(n_atoms/atomicity, 0);
+
+  // Prepare an atom in this container for each line read.
+  Atom<spacedim> temporary_atom;
+
+  // Store atom attributes and positions.
+  types::global_atom_index i=0;
+  while ( std::getline(is,line) && i < n_atoms)
+    {
+      ++line_no;
+      line = strip(line);
+      if ( line.size()==0)
+        continue;
+
+      // Not reading molecular_id
+      if (sscanf(line.c_str(), "%llu  %llu " UC_SCANF_STR " %lf %lf %lf %lf",
+                 &i_atom_index,
+                 &i_molecule_index,
+                 &i_atom_char_type,
+                 &i_q,
+                 &position[0],
+                 &position[1],
+                 &position[2]) !=7)
+        AssertThrow (false,
+                     ExcInvalidValue( line_no,
+                                      "atom attributes under Atom keyword section"));
+
+      Assert (i_atom_index<=n_atoms && i_atom_index>0,
+              ExcInvalidValue( line_no,
+                               "atom index (> number of atoms or <=0"));
+
+      temporary_atom.global_index =
+        static_cast<types::global_atom_index>(i_atom_index) - 1;
+
+      i_atom_type = static_cast<types::atom_type> (i_atom_char_type) - 1;
+      temporary_atom.type = i_atom_type;
+
+      Assert (i_atom_type >= 0 && i_atom_type < 256,
+              ExcInvalidValue(line_no, "atom type attribute"));
+
+      // TODO: 1 and 2 dim cases could be potentially incorrect
+      // Possible way to correct this is to ask user axes dimensionality
+      Assert (spacedim <=3, ExcNotImplemented());
+
+      for (int d = 0; d < spacedim; ++d)
+        temporary_atom.position[d] = position[d];
+
+      temporary_atom.initial_position = temporary_atom.position;
+
+      //---Atom attributes are prepared for temporary_atom.
+
+      //---Prepare charges.
+
+      if (std::find(unique_types.begin(), unique_types.end(), i_atom_type) == unique_types.end())
+        {
+          unique_types.push_back(i_atom_type);
+          charges[i_atom_type] = static_cast<types::charge>(i_q);
+        }
+      else
+        Assert (charges[i_atom_type]==static_cast<types::charge>(i_q),
+                ExcInvalidValue(line_no, "charge attribute"));
+
+      //---Ready to insert atom into molecule.
+
+      i_molecule = static_cast<types::global_atom_index>(i_molecule_index) - 1;
+
+      // Set molecule global id
+      molecules[i_molecule].global_index = i_molecule;
+
+      // Add atom to the molecule.
+      molecules[i_molecule].atoms[n_atoms_added_per_molecule[i_molecule]] =
+        temporary_atom;
+
+      // Increment the number of atoms added to ith molecule.
+      n_atoms_added_per_molecule[i_molecule]++;
+
+      // Set some member variables of i_molecule to invalid values as
+      // the current class cannot initialize to correct values.
+      molecules[i_molecule].local_index    = dealii::numbers::invalid_unsigned_int;
+      molecules[i_molecule].cluster_weight = numbers::invalid_cluster_weight;
+
+      ++i;
+    }
+
+  Assert (unique_types.size()==n_atom_types,
+          ExcInternalError());
+
+  Assert (i==n_atoms,
+          ExcMessage("The number of atoms do not match the number of entries "
+                     "under Atoms keyword section"));
+
+  //---At this point atoms in molecules are not sorted according to their
+  //   stamps.
+
+  //---For now it is not possible to ensure correct order of stamps for
+  //   repeated atom types.
+  //   Example: A2B molecule could have two possible stamp orderings.
+  //
+  //   case 1:  0 1 2         ----------> stamp order
+  //            0 0 1         ----------> type order
+  //
+  //   case 2:  1 0 2         ----------> stamp order
+  //            0 0 1         ----------> type order
+
+  // Making a lambda for atom type comparision
+  auto comparator_atom_type = [] (const decltype(temporary_atom) &a,
+                                  const decltype(temporary_atom) &b)
   {
-    std::string line;
-    size_t i_atom_type;
-    double i_mass;
+    return a.type < b.type;
+  };
 
-    size_t i=0;
-    // Store atom masses for different atom types
-    while ( std::getline(is,line) && i<n_atom_types)
-      {
-        ++line_no;
-        line = strip(line);
-        if ( line.size()==0)
-          continue;
+  for (auto &molecule : molecules)
+    {
+      std::sort (molecule.atoms.begin(),
+                 molecule.atoms.end(),
+                 comparator_atom_type);
+    }
 
-        if (sscanf(line.c_str(), "%zu %lf", &i_atom_type, &i_mass) !=2)
-          AssertThrow( false, ExcInvalidValue(line_no,"Mass"));
-
-        Assert( i_atom_type <= n_atom_types && i_atom_type>0,
-                ExcInvalidValue( line_no, "atom type index (> number of atom types "
-                                 "or <= 0)"));
-
-        // Copy masses for all atom types
-        masses[i_atom_type-1] = i_mass;
-        ++i;
-      }
-    line_no++;
-    Assert (i==masses.size(),
-            ExcMessage("The number of different atom types "
-                       "do not match the number of entries "
-                       "under Masses keyword section"));
-    return;
-  }
+  return;
+}
 
 
 
-  template<int spacedim, int atomicity>
-  std::string
-  ParseAtomData<spacedim, atomicity>::strip (const std::string &input)
-  {
-    std::string line(input);
+template<int spacedim, int atomicity>
+void
+ParseAtomData<spacedim, atomicity>::parse_masses (std::istream        &is,
+                                                  std::vector<double> &masses)
+{
+  std::string line;
+  size_t i_atom_type;
+  double i_mass;
 
-    // Find if # is present
-    size_t trim_pos = line.find("#");
+  size_t i=0;
+  // Store atom masses for different atom types
+  while ( std::getline(is,line) && i<n_atom_types)
+    {
+      ++line_no;
+      line = strip(line);
+      if ( line.size()==0)
+        continue;
 
-    // Trim all the stuff after #
-    if ( trim_pos != std::string::npos )
-      line.resize( trim_pos );
+      if (sscanf(line.c_str(), "%zu %lf", &i_atom_type, &i_mass) !=2)
+        AssertThrow( false, ExcInvalidValue(line_no,"Mass"));
 
-    // Trim line from left and right with " \t\n\r"
-    line = dealii::Utilities::trim(line);
+      Assert( i_atom_type <= n_atom_types && i_atom_type>0,
+              ExcInvalidValue( line_no, "atom type index (> number of atom types "
+                               "or <= 0)"));
 
-    return line;
-  }
+      // Copy masses for all atom types
+      masses[i_atom_type-1] = i_mass;
+      ++i;
+    }
+  line_no++;
+  Assert (i==masses.size(),
+          ExcMessage("The number of different atom types "
+                     "do not match the number of entries "
+                     "under Masses keyword section"));
+  return;
+}
+
+
+
+template<int spacedim, int atomicity>
+std::string
+ParseAtomData<spacedim, atomicity>::strip (const std::string &input)
+{
+  std::string line(input);
+
+  // Find if # is present
+  size_t trim_pos = line.find("#");
+
+  // Trim all the stuff after #
+  if ( trim_pos != std::string::npos )
+    line.resize( trim_pos );
+
+  // Trim line from left and right with " \t\n\r"
+  line = dealii::Utilities::trim(line);
+
+  return line;
+}
 
 
 #define PARSE_ATOM_DATA(R, X) \
   template class ParseAtomData< FIRST_OF_TWO_IS_SPACEDIM(X), \
                                 SECOND_OF_TWO_IS_ATOMICITY(X)>;
 
-  INSTANTIATE_WITH_SPACEDIM_AND_ATOMICITY(R, PARSE_ATOM_DATA)
+INSTANTIATE_WITH_SPACEDIM_AND_ATOMICITY(R, PARSE_ATOM_DATA)
 
-} /* namespace dealiiqc */
+
+DEAL_II_QC_NAMESPACE_CLOSE


### PR DESCRIPTION
Didn't expect adding this will cause such a chaotic diff.

This PR doesn't apply these definitions to (`source/atom/cell_molecule_tools.cc`, `source/atom/cell_molecule_tools.h`); will do after #147.