### PR TITLE
reworked extract_locally_relevant_dofs

### DIFF
--- a/include/deal.II-qc/atom/cell_molecule_tools.h
+++ b/include/deal.II-qc/atom/cell_molecule_tools.h
@@ -93,11 +93,11 @@ namespace CellMoleculeTools
    * DoFHandler::locally_owned_dofs() and the DoF indices on all locally
    * relevant ghost cells.
    */
-  template <int dim, int atomicity, int spacedim>
+  template <int dim, int spacedim>
   IndexSet
   extract_locally_relevant_dofs
-  (const types::MeshType<dim, spacedim>                             &dof_handler,
-   const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules);
+  (const DoFHandler<dim, spacedim> &dof_handler,
+   const double                     ghost_cell_layer_thickness);
 
 
 } // namespace CellMoleculeTools

--- a/include/deal.II-qc/utilities.h
+++ b/include/deal.II-qc/utilities.h
@@ -39,6 +39,23 @@
 
 
 /**
+ * A macro function that returns 1 if @p DIM is less or equal to @p SPACEDIM
+ * and 0 otherwise.
+ */
+#define IS_DIM_AND_SPACEDIM_PAIR_VALID(DIM, SPACEDIM) \
+  BOOST_PP_LESS_EQUAL(DIM, SPACEDIM)
+
+
+
+/**
+ * A macro to expand CLASS macro using (DIM, SPACEDIM) tuples.
+ */
+#define INSTANTIATE_WITH_DIM_AND_SPACEDIM(CLASS) \
+  BOOST_PP_LIST_FOR_EACH_PRODUCT(CLASS, 2, (DIM, SPACEDIM))
+
+
+
+/**
  * A macro to expand CLASS macro using (SPACEDIM, ATOMICITY) tuples.
  */
 #define INSTANTIATE_WITH_SPACEDIM_AND_ATOMICITY(R, CLASS) \

--- a/source/core/qc.cc
+++ b/source/core/qc.cc
@@ -163,7 +163,7 @@ void QC<dim, PotentialType>::setup_system ()
   locally_relevant_set =
     CellMoleculeTools::
     extract_locally_relevant_dofs (dof_handler,
-                                   cell_molecule_data.cell_molecules);
+                                   configure_qc.get_ghost_cell_layer_thickness());
 
   // set-up constraints objects
   constraints.reinit (locally_relevant_set);

--- a/tests/atom/cell_molecule_tools_extract_dofs_01.cc
+++ b/tests/atom/cell_molecule_tools_extract_dofs_01.cc
@@ -78,7 +78,7 @@ public:
     const IndexSet locally_relevant_set =
       CellMoleculeTools::
       extract_locally_relevant_dofs (dof_handler,
-                                     cell_molecule_data.cell_molecules);
+                                     config.get_ghost_cell_layer_thickness());
 
     unsigned int
     n_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(mpi_communicator),


### PR DESCRIPTION
+ `CellMoleculeTools::extract_locally_relevant_dofs()` doesn't need to know about cell molecules. It could just use `ghost_cell_layer_thickness` to pick up relevant dofs. 

+ if some cells do not have atoms/molecules, it is not picked up in `cell_molecules` and consequently previous version of `CellMoleculeTools::extract_locally_relevant_dofs()` gives incorrect results.

+ previous written test passes
