### PR TITLE
minor code formatting

### DIFF
--- a/include/deal.II-qc/atom/sampling/cluster_weights_by_base.h
+++ b/include/deal.II-qc/atom/sampling/cluster_weights_by_base.h
@@ -53,8 +53,9 @@ namespace Cluster
      */
     virtual
     types::CellMoleculeContainerType<dim, atomicity, spacedim>
-    update_cluster_weights (const types::MeshType<dim, spacedim> &mesh,
-                            const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const = 0;
+    update_cluster_weights
+    (const types::MeshType<dim, spacedim>                             &mesh,
+     const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const = 0;
 
   protected:
 

--- a/include/deal.II-qc/atom/sampling/cluster_weights_by_cell.h
+++ b/include/deal.II-qc/atom/sampling/cluster_weights_by_cell.h
@@ -33,8 +33,9 @@ namespace Cluster
      * as cluster weights.
      */
     types::CellMoleculeContainerType<dim, atomicity, spacedim>
-    update_cluster_weights (const types::MeshType<dim, spacedim> &mesh,
-                            const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const;
+    update_cluster_weights
+    (const types::MeshType<dim, spacedim>                             &mesh,
+     const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const;
 
   };
 

--- a/include/deal.II-qc/atom/sampling/cluster_weights_by_lumped_vertex.h
+++ b/include/deal.II-qc/atom/sampling/cluster_weights_by_lumped_vertex.h
@@ -83,8 +83,9 @@ namespace Cluster
      * class description.
      */
     types::CellMoleculeContainerType<dim, atomicity, spacedim>
-    update_cluster_weights (const types::MeshType<dim, spacedim> &mesh,
-                            const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const;
+    update_cluster_weights
+    (const types::MeshType<dim, spacedim>                             &mesh,
+     const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const;
 
   };
 

--- a/include/deal.II-qc/atom/sampling/cluster_weights_by_vertex.h
+++ b/include/deal.II-qc/atom/sampling/cluster_weights_by_vertex.h
@@ -38,8 +38,9 @@ namespace Cluster
      * point.
      */
     types::CellMoleculeContainerType<dim, atomicity, spacedim>
-    update_cluster_weights (const types::MeshType<dim, spacedim> &mesh,
-                            const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const;
+    update_cluster_weights
+    (const types::MeshType<dim, spacedim>                             &mesh,
+     const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const;
 
   };
 

--- a/source/atom/cell_molecule_tools.cc
+++ b/source/atom/cell_molecule_tools.cc
@@ -65,7 +65,7 @@ namespace CellMoleculeTools
   template<int dim, int atomicity, int spacedim>
   unsigned int
   n_cluster_molecules_in_cell
-  (const types::CellIteratorType<dim, spacedim> &cell,
+  (const types::CellIteratorType<dim, spacedim>                     &cell,
    const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_energy_molecules)
   {
     const types::CellMoleculeConstIteratorRangeType<dim, atomicity, spacedim>

--- a/source/atom/data_out_atom_data.cc
+++ b/source/atom/data_out_atom_data.cc
@@ -18,8 +18,8 @@ namespace DataOutBase
   class VtpStream
   {
   public:
-    VtpStream ( std::ostream &stream,
-                const VtkFlags &flags)
+    VtpStream (std::ostream &stream,
+               const VtkFlags &flags)
       :
       stream (stream), flags (flags)
     {}
@@ -167,7 +167,7 @@ namespace
   /**
    * Write out into ostream object @p out the vtp header
    */
-  void write_vtp_header (std::ostream &out,
+  void write_vtp_header (std::ostream                &out,
                          const DataOutBase::VtkFlags &flags)
   {
     AssertThrow (out, ExcIO());
@@ -372,7 +372,7 @@ write_pvtp_record (const std::vector<std::string>      &vtp_file_names,
   template void DataOutAtomData::write_vtp<DIM, ATOMICITY, SPACEDIM>      \
   (const types::CellMoleculeContainerType<DIM, ATOMICITY, SPACEDIM> &,    \
    const dealii::DataOutBase::VtkFlags                              &,    \
-   std::ostream                                                    &);   \
+   std::ostream                                                     &);   \
    
 #define DATA_OUT_ATOM_DATA(R, X)                       \
   BOOST_PP_IF(IS_DIM_LESS_EQUAL_SPACEDIM X,            \

--- a/source/atom/sampling/cluster_weights_by_cell.cc
+++ b/source/atom/sampling/cluster_weights_by_cell.cc
@@ -22,8 +22,9 @@ namespace Cluster
   template <int dim, int atomicity, int spacedim>
   types::CellMoleculeContainerType<dim, atomicity, spacedim>
   WeightsByCell<dim, atomicity, spacedim>::
-  update_cluster_weights (const types::MeshType<dim, spacedim> &mesh,
-                          const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const
+  update_cluster_weights
+  (const types::MeshType<dim, spacedim>                             &mesh,
+   const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const
   {
     // Prepare energy molecules in this container.
     types::CellMoleculeContainerType<dim, atomicity, spacedim>

--- a/source/atom/sampling/cluster_weights_by_lumped_vertex.cc
+++ b/source/atom/sampling/cluster_weights_by_lumped_vertex.cc
@@ -28,8 +28,9 @@ namespace Cluster
   template <int dim, int atomicity, int spacedim>
   types::CellMoleculeContainerType<dim, atomicity, spacedim>
   WeightsByLumpedVertex<dim, atomicity, spacedim>::
-  update_cluster_weights (const types::MeshType<dim, spacedim> &mesh,
-                          const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const
+  update_cluster_weights
+  (const types::MeshType<dim, spacedim>                             &mesh,
+   const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const
   {
     // Prepare energy molecules in this container.
     types::CellMoleculeContainerType<dim, atomicity, spacedim>

--- a/source/atom/sampling/cluster_weights_by_vertex.cc
+++ b/source/atom/sampling/cluster_weights_by_vertex.cc
@@ -25,8 +25,9 @@ namespace Cluster
   template<int dim, int atomicity, int spacedim>
   types::CellMoleculeContainerType<dim, atomicity, spacedim>
   WeightsByVertex<dim, atomicity, spacedim>::
-  update_cluster_weights (const types::MeshType<dim, spacedim> &mesh,
-                          const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const
+  update_cluster_weights
+  (const types::MeshType<dim, spacedim>                             &mesh,
+   const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const
   {
     // Prepare energy molecules in this container.
     types::CellMoleculeContainerType<dim, atomicity, spacedim>

--- a/source/configure/configure_qc.cc
+++ b/source/configure/configure_qc.cc
@@ -9,15 +9,15 @@ using namespace dealii;
 
 // Initialize dimension to a default unusable value
 // Imposes user to `set Dimension`
-ConfigureQC::ConfigureQC( std::shared_ptr<std::istream> is)
+ConfigureQC::ConfigureQC (std::shared_ptr<std::istream> is)
   :
   dimension(0),
   input_stream(is)
 {
-  AssertThrow( *input_stream, ExcIO() );
+  AssertThrow (*input_stream, ExcIO());
   ParameterHandler prm;
   declare_parameters(prm);
-  prm.parse_input (*input_stream,"dummy","#end-of-parameter-section");
+  prm.parse_input (*input_stream, "dummy", "#end-of-parameter-section");
   parse_parameters(prm);
 }
 
@@ -119,7 +119,7 @@ ConfigureQC::get_cluster_weights() const
 
 
 
-void ConfigureQC::declare_parameters( ParameterHandler &prm )
+void ConfigureQC::declare_parameters (ParameterHandler &prm)
 {
   // TODO: Write intput file name to the screen
   //deallog << std::endl << "Parsing qc input file " << filename << std::endl
@@ -205,7 +205,7 @@ void ConfigureQC::declare_parameters( ParameterHandler &prm )
 
 
 
-void ConfigureQC::parse_parameters( ParameterHandler &prm )
+void ConfigureQC::parse_parameters (ParameterHandler &prm)
 {
   dimension = prm.get_integer("Dimension");
 

--- a/source/potentials/pair_coul_wolf.cc
+++ b/source/potentials/pair_coul_wolf.cc
@@ -44,4 +44,5 @@ namespace Potential
 
 } // namespace Potential
 
+
 DEAL_II_QC_NAMESPACE_CLOSE


### PR DESCRIPTION
Code formatting for legibility and uniformity. Functionality is not touched.

PS: I pushed `v0.0.2` tag just before this commit.