### PR TITLE
remove MeshType; CellMoleculeData is now Tria based instead of DoF

### DIFF
--- a/include/deal.II-qc/atom/cell_molecule_tools.h
+++ b/include/deal.II-qc/atom/cell_molecule_tools.h
@@ -81,9 +81,9 @@ namespace CellMoleculeTools
    */
   template<int dim, int atomicity=1, int spacedim=dim>
   CellMoleculeData<dim, atomicity, spacedim>
-  build_cell_molecule_data (std::istream                         &is,
-                            const types::MeshType<dim, spacedim> &mesh,
-                            double          ghost_cell_layer_thickness);
+  build_cell_molecule_data (std::istream                            &is,
+                            const dealii::DoFHandler<dim, spacedim> &mesh,
+                            const double       ghost_cell_layer_thickness);
 
   /**
    * Return the set of global DoF indices of the locally relevant DoFs on the

--- a/include/deal.II-qc/atom/sampling/cluster_weights_by_base.h
+++ b/include/deal.II-qc/atom/sampling/cluster_weights_by_base.h
@@ -54,7 +54,7 @@ namespace Cluster
     virtual
     types::CellMoleculeContainerType<dim, atomicity, spacedim>
     update_cluster_weights
-    (const types::MeshType<dim, spacedim>                             &mesh,
+    (const dealii::DoFHandler<dim, spacedim>                          &mesh,
      const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const = 0;
 
   protected:

--- a/include/deal.II-qc/atom/sampling/cluster_weights_by_cell.h
+++ b/include/deal.II-qc/atom/sampling/cluster_weights_by_cell.h
@@ -34,7 +34,7 @@ namespace Cluster
      */
     types::CellMoleculeContainerType<dim, atomicity, spacedim>
     update_cluster_weights
-    (const types::MeshType<dim, spacedim>                             &mesh,
+    (const dealii::DoFHandler<dim, spacedim>                          &mesh,
      const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const;
 
   };

--- a/include/deal.II-qc/atom/sampling/cluster_weights_by_lumped_vertex.h
+++ b/include/deal.II-qc/atom/sampling/cluster_weights_by_lumped_vertex.h
@@ -84,7 +84,7 @@ namespace Cluster
      */
     types::CellMoleculeContainerType<dim, atomicity, spacedim>
     update_cluster_weights
-    (const types::MeshType<dim, spacedim>                             &mesh,
+    (const dealii::DoFHandler<dim, spacedim>                          &mesh,
      const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const;
 
   };

--- a/include/deal.II-qc/atom/sampling/cluster_weights_by_vertex.h
+++ b/include/deal.II-qc/atom/sampling/cluster_weights_by_vertex.h
@@ -39,7 +39,7 @@ namespace Cluster
      */
     types::CellMoleculeContainerType<dim, atomicity, spacedim>
     update_cluster_weights
-    (const types::MeshType<dim, spacedim>                             &mesh,
+    (const dealii::DoFHandler<dim, spacedim>                          &mesh,
      const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const;
 
   };

--- a/include/deal.II-qc/core/qc.h
+++ b/include/deal.II-qc/core/qc.h
@@ -275,7 +275,7 @@ protected:
   /**
    * Map of cells to data.
    */
-  std::map<typename DoFHandler<dim>::active_cell_iterator, AssemblyData>
+  std::map<types::DoFCellIteratorType<dim>, AssemblyData>
   cells_to_data;
 
   /**

--- a/include/deal.II-qc/utilities.h
+++ b/include/deal.II-qc/utilities.h
@@ -12,7 +12,6 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/dofs/dof_handler.h>
 
 
 
@@ -114,17 +113,18 @@ namespace types
   typedef unsigned char atom_type;
 
   /**
-   * A typedef for mesh.
+   * A typedef for Triangulation's active_cell_iterator for ease of use.
    */
   template<int dim, int spacedim=dim>
-  using MeshType = dealii::DoFHandler<dim, spacedim>;
+  using CellIteratorType =
+    typename dealii::Triangulation<dim, spacedim>::active_cell_iterator;
 
   /**
    * A typedef for DoFHandler's active_cell_iterator for ease of use.
    */
   template<int dim, int spacedim=dim>
-  using CellIteratorType =
-    typename MeshType<dim, spacedim>::active_cell_iterator;
+  using DoFCellIteratorType =
+    typename dealii::DoFHandler<dim, spacedim>::active_cell_iterator;
 
   /**
    * A typedef for DoFHandler's const active_cell_iterator for ease of use.

--- a/source/atom/cell_molecule_tools.cc
+++ b/source/atom/cell_molecule_tools.cc
@@ -103,9 +103,9 @@ namespace CellMoleculeTools
 
   template<int dim, int atomicity, int spacedim>
   CellMoleculeData<dim, atomicity, spacedim>
-  build_cell_molecule_data (std::istream                         &is,
-                            const types::MeshType<dim, spacedim> &mesh,
-                            double          ghost_cell_layer_thickness)
+  build_cell_molecule_data (std::istream                            &is,
+                            const dealii::DoFHandler<dim, spacedim> &mesh,
+                            const double       ghost_cell_layer_thickness)
   {
     // TODO: Assign atoms to cells as we parse atom data ?
     //       relevant for when we have a large collection of atoms.
@@ -139,7 +139,7 @@ namespace CellMoleculeTools
 
     // Loop through all the locally owned cells and
     // mark (true) all the vertices of the locally owned cells.
-    for (typename types::MeshType<dim, spacedim>::active_cell_iterator
+    for (typename dealii::DoFHandler<dim, spacedim>::active_cell_iterator
          cell = mesh.begin_active();
          cell != mesh.end(); ++cell)
       if (cell->is_locally_owned())
@@ -154,7 +154,7 @@ namespace CellMoleculeTools
     // If the total number of MPI processes is just one,
     // the size of ghost_cells vector is zero.
     const
-    std::vector<typename types::MeshType<dim, spacedim>::active_cell_iterator>
+    std::vector<typename dealii::DoFHandler<dim, spacedim>::active_cell_iterator>
     ghost_cells =
       GridTools::
       compute_ghost_cell_layer_within_distance (mesh,
@@ -182,7 +182,7 @@ namespace CellMoleculeTools
             // Find the locally active cell of the provided mesh which
             // surrounds the initial location of the molecule.
             std::pair<
-            typename types::MeshType<dim, spacedim>::active_cell_iterator
+            typename dealii::DoFHandler<dim, spacedim>::active_cell_iterator
             ,
             Point<dim>
             >
@@ -300,9 +300,9 @@ namespace CellMoleculeTools
   \
   template                                                               \
   CellMoleculeData<DIM, ATOMICITY, SPACEDIM>                             \
-  build_cell_molecule_data (std::istream                         &,      \
-                            const types::MeshType<DIM, SPACEDIM> &,      \
-                            double                               );      \
+  build_cell_molecule_data (std::istream                            &,   \
+                            const dealii::DoFHandler<DIM, SPACEDIM> &,   \
+                            const double                             );  \
    
 #define CELL_MOLECULE_TOOLS(R, X)                                        \
   BOOST_PP_IF(IS_DIM_LESS_EQUAL_SPACEDIM X,                              \

--- a/source/atom/sampling/cluster_weights_by_cell.cc
+++ b/source/atom/sampling/cluster_weights_by_cell.cc
@@ -23,7 +23,7 @@ namespace Cluster
   types::CellMoleculeContainerType<dim, atomicity, spacedim>
   WeightsByCell<dim, atomicity, spacedim>::
   update_cluster_weights
-  (const types::MeshType<dim, spacedim>                             &mesh,
+  (const dealii::DoFHandler<dim, spacedim>                          &mesh,
    const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const
   {
     // Prepare energy molecules in this container.

--- a/source/atom/sampling/cluster_weights_by_vertex.cc
+++ b/source/atom/sampling/cluster_weights_by_vertex.cc
@@ -26,7 +26,7 @@ namespace Cluster
   types::CellMoleculeContainerType<dim, atomicity, spacedim>
   WeightsByVertex<dim, atomicity, spacedim>::
   update_cluster_weights
-  (const types::MeshType<dim, spacedim>                             &mesh,
+  (const dealii::DoFHandler<dim, spacedim>                          &mesh,
    const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const
   {
     // Prepare energy molecules in this container.


### PR DESCRIPTION
+ `CellMoleculeData`'s members are now based on `TriaAccessor`s instead if `DoFAccessor`s.
+ Removed `MeshType` typedef so that they are just `DoFHandler` wherever `MeshType` was previously used.
+ All tests passing.

In the next PRs, I can now work on `Cluster::WeightsByBase` class by moving from using `DoFHandler` to `Triangulation`.