### PR TITLE
using tria instead of dof handler while building cell molecules

### DIFF
--- a/include/deal.II-qc/atom/atom.h
+++ b/include/deal.II-qc/atom/atom.h
@@ -19,7 +19,7 @@ using namespace dealii;
  * atomistic system is far less than the number of atoms. The charges and
  * masses of different atom types can be stored elsewhere in a central pool.
  *
- * A drude particles can be constructed using two Atom objects. One object for
+ * A drude particle can be constructed using two Atom objects. One object for
  * the charged core and another for the charged shell.
  */
 template <int spacedim>

--- a/include/deal.II-qc/atom/cell_molecule_data.h
+++ b/include/deal.II-qc/atom/cell_molecule_data.h
@@ -89,8 +89,9 @@ namespace types
  *
  * The association between molecules and cells allows for accessing each
  * molecule through its associated cell. The cell based molecule data
- * structures in this class can be initialized using MoleculeHandler
- * class member functions.
+ * structures in this class can be initialized using
+ * CellMoleculeTools::build_cell_molecule_data() and (derived class)
+ * implementation of Cluster::WeightsByBase::update_cluster_weights().
  */
 template<int dim, int atomicity=1, int spacedim=dim>
 struct CellMoleculeData

--- a/include/deal.II-qc/atom/cell_molecule_tools.h
+++ b/include/deal.II-qc/atom/cell_molecule_tools.h
@@ -81,9 +81,9 @@ namespace CellMoleculeTools
    */
   template<int dim, int atomicity=1, int spacedim=dim>
   CellMoleculeData<dim, atomicity, spacedim>
-  build_cell_molecule_data (std::istream                            &is,
-                            const dealii::DoFHandler<dim, spacedim> &mesh,
-                            const double       ghost_cell_layer_thickness);
+  build_cell_molecule_data (std::istream                       &is,
+                            const Triangulation<dim, spacedim> &mesh,
+                            const double  ghost_cell_layer_thickness);
 
   /**
    * Return the set of global DoF indices of the locally relevant DoFs on the

--- a/source/atom/cell_molecule_tools.cc
+++ b/source/atom/cell_molecule_tools.cc
@@ -103,9 +103,9 @@ namespace CellMoleculeTools
 
   template<int dim, int atomicity, int spacedim>
   CellMoleculeData<dim, atomicity, spacedim>
-  build_cell_molecule_data (std::istream                            &is,
-                            const dealii::DoFHandler<dim, spacedim> &mesh,
-                            const double       ghost_cell_layer_thickness)
+  build_cell_molecule_data (std::istream                       &is,
+                            const Triangulation<dim, spacedim> &mesh,
+                            const double  ghost_cell_layer_thickness)
   {
     // TODO: Assign atoms to cells as we parse atom data ?
     //       relevant for when we have a large collection of atoms.
@@ -129,7 +129,7 @@ namespace CellMoleculeTools
     cell_molecule_data.charges =
       std::make_shared<std::vector<types::charge>>(charges);
 
-    const unsigned int n_vertices =  mesh.get_triangulation().n_vertices();
+    const unsigned int n_vertices =  mesh.n_vertices();
 
     // In order to speed-up finding an active cell around atoms through
     // find_active_cell_around_point(), we will need to construct a
@@ -139,7 +139,7 @@ namespace CellMoleculeTools
 
     // Loop through all the locally owned cells and
     // mark (true) all the vertices of the locally owned cells.
-    for (typename dealii::DoFHandler<dim, spacedim>::active_cell_iterator
+    for (types::CellIteratorType<dim, spacedim>
          cell = mesh.begin_active();
          cell != mesh.end(); ++cell)
       if (cell->is_locally_owned())
@@ -154,7 +154,7 @@ namespace CellMoleculeTools
     // If the total number of MPI processes is just one,
     // the size of ghost_cells vector is zero.
     const
-    std::vector<typename dealii::DoFHandler<dim, spacedim>::active_cell_iterator>
+    std::vector<types::CellIteratorType<dim, spacedim> >
     ghost_cells =
       GridTools::
       compute_ghost_cell_layer_within_distance (mesh,
@@ -181,11 +181,7 @@ namespace CellMoleculeTools
           {
             // Find the locally active cell of the provided mesh which
             // surrounds the initial location of the molecule.
-            std::pair<
-            typename dealii::DoFHandler<dim, spacedim>::active_cell_iterator
-            ,
-            Point<dim>
-            >
+            std::pair<types::CellIteratorType<dim, spacedim>, Point<dim> >
             my_pair =
               GridTools::
               find_active_cell_around_point (MappingQ1<dim,spacedim>(),
@@ -300,9 +296,9 @@ namespace CellMoleculeTools
   \
   template                                                               \
   CellMoleculeData<DIM, ATOMICITY, SPACEDIM>                             \
-  build_cell_molecule_data (std::istream                            &,   \
-                            const dealii::DoFHandler<DIM, SPACEDIM> &,   \
-                            const double                             );  \
+  build_cell_molecule_data (std::istream                       &,        \
+                            const Triangulation<DIM, SPACEDIM> &,        \
+                            const double                       );        \
    
 #define CELL_MOLECULE_TOOLS(R, X)                                        \
   BOOST_PP_IF(IS_DIM_LESS_EQUAL_SPACEDIM X,                              \

--- a/source/core/qc.cc
+++ b/source/core/qc.cc
@@ -101,14 +101,14 @@ void QC<dim, PotentialType>::setup_cell_molecules()
       cell_molecule_data =
         CellMoleculeTools::build_cell_molecule_data<dim>
         (fin,
-         dof_handler,
+         triangulation,
          configure_qc.get_ghost_cell_layer_thickness());
     }
   else if ( !(* configure_qc.get_stream()).eof() )
     cell_molecule_data =
       CellMoleculeTools::build_cell_molecule_data<dim>
       (*configure_qc.get_stream(),
-       dof_handler,
+       triangulation,
        configure_qc.get_ghost_cell_layer_thickness());
   else
     AssertThrow(false,

--- a/tests/atom/cell_molecule_tools_00.cc
+++ b/tests/atom/cell_molecule_tools_00.cc
@@ -41,7 +41,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (fin,
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     std::shared_ptr<Cluster::WeightsByBase<dim> > cluster_weights_method =

--- a/tests/atom/cell_molecule_tools_01.cc
+++ b/tests/atom/cell_molecule_tools_01.cc
@@ -34,7 +34,6 @@ public:
     triangulation (MPI_COMM_WORLD,
                    // guarantee that the mesh also does not change by more than refinement level across vertices that might connect two cells:
                    Triangulation<dim>::limit_level_difference_at_vertices),
-    dof_handler    (triangulation),
     mpi_communicator(MPI_COMM_WORLD)
   {}
 
@@ -45,7 +44,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (*config.get_stream(),
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     std::shared_ptr<Cluster::WeightsByBase<dim> > cluster_weights_method =
@@ -99,7 +98,6 @@ public:
 private:
   const ConfigureQC &config;
   parallel::shared::Triangulation<dim> triangulation;
-  DoFHandler<dim>      dof_handler;
   MPI_Comm mpi_communicator;
   CellMoleculeData<dim> cell_molecule_data;
 

--- a/tests/atom/cell_molecule_tools_02.cc
+++ b/tests/atom/cell_molecule_tools_02.cc
@@ -34,7 +34,6 @@ public:
     triangulation (MPI_COMM_WORLD,
                    // guarantee that the mesh also does not change by more than refinement level across vertices that might connect two cells:
                    Triangulation<dim>::limit_level_difference_at_vertices),
-    dof_handler    (triangulation),
     mpi_communicator(MPI_COMM_WORLD)
   {}
 
@@ -49,7 +48,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (fin,
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     std::shared_ptr<Cluster::WeightsByBase<dim> > cluster_weights_method =
@@ -93,7 +92,6 @@ public:
 private:
   const ConfigureQC &config;
   parallel::shared::Triangulation<dim> triangulation;
-  DoFHandler<dim>      dof_handler;
   MPI_Comm mpi_communicator;
   CellMoleculeData<dim> cell_molecule_data;
 

--- a/tests/atom/cell_molecule_tools_cluster_weight_01.cc
+++ b/tests/atom/cell_molecule_tools_cluster_weight_01.cc
@@ -35,7 +35,6 @@ public:
     triangulation (MPI_COMM_WORLD,
                    // guarantee that the mesh also does not change by more than refinement level across vertices that might connect two cells:
                    Triangulation<dim>::limit_level_difference_at_vertices),
-    dof_handler    (triangulation),
     mpi_communicator(MPI_COMM_WORLD)
   {}
 
@@ -46,7 +45,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (*config.get_stream(),
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     std::shared_ptr<Cluster::WeightsByBase<dim> > cluster_weights_method =
@@ -69,7 +68,6 @@ public:
 private:
   const ConfigureQC &config;
   parallel::shared::Triangulation<dim> triangulation;
-  DoFHandler<dim>      dof_handler;
   MPI_Comm mpi_communicator;
   CellMoleculeData<dim> cell_molecule_data;
 

--- a/tests/atom/cell_molecule_tools_cluster_weight_02.cc
+++ b/tests/atom/cell_molecule_tools_cluster_weight_02.cc
@@ -33,7 +33,6 @@ public:
     triangulation (MPI_COMM_WORLD,
                    // guarantee that the mesh also does not change by more than refinement level across vertices that might connect two cells:
                    Triangulation<dim>::limit_level_difference_at_vertices),
-    dof_handler    (triangulation),
     mpi_communicator(MPI_COMM_WORLD)
   {}
 
@@ -46,7 +45,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (*config.get_stream(),
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     std::shared_ptr<Cluster::WeightsByBase<dim> > cluster_weights_method =
@@ -69,7 +68,6 @@ public:
 private:
   const ConfigureQC &config;
   parallel::shared::Triangulation<dim> triangulation;
-  DoFHandler<dim>      dof_handler;
   MPI_Comm mpi_communicator;
   CellMoleculeData<dim> cell_molecule_data;
 

--- a/tests/atom/cell_molecule_tools_extract_dofs_01.cc
+++ b/tests/atom/cell_molecule_tools_extract_dofs_01.cc
@@ -72,7 +72,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (*config.get_stream(),
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     const IndexSet locally_relevant_set =

--- a/tests/atom/cell_molecule_tools_n_cluster_01.cc
+++ b/tests/atom/cell_molecule_tools_n_cluster_01.cc
@@ -35,7 +35,6 @@ public:
     triangulation (MPI_COMM_WORLD,
                    // guarantee that the mesh also does not change by more than refinement level across vertices that might connect two cells:
                    Triangulation<dim>::limit_level_difference_at_vertices),
-    dof_handler    (triangulation),
     mpi_communicator(MPI_COMM_WORLD)
   {}
 
@@ -48,7 +47,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (*config.get_stream(),
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     std::shared_ptr<Cluster::WeightsByBase<dim> > cluster_weights_method =
@@ -70,7 +69,7 @@ public:
                 << cell_molecule.second.cluster_weight << std::endl;
 
     const unsigned int n_cluster_molecules =
-      CellMoleculeTools::n_cluster_molecules_in_cell<dim> (dof_handler.begin_active(),
+      CellMoleculeTools::n_cluster_molecules_in_cell<dim> (triangulation.begin_active(),
                                                            cell_energy_molecules);
     AssertThrow(n_cluster_molecules == 10,
                 ExcInternalError());
@@ -79,7 +78,6 @@ public:
 private:
   const ConfigureQC &config;
   parallel::shared::Triangulation<dim> triangulation;
-  DoFHandler<dim>      dof_handler;
   MPI_Comm mpi_communicator;
   CellMoleculeData<dim> cell_molecule_data;
 

--- a/tests/atom/cell_molecule_tools_thrown_molecules_01.cc
+++ b/tests/atom/cell_molecule_tools_thrown_molecules_01.cc
@@ -31,7 +31,6 @@ public:
     triangulation (MPI_COMM_WORLD,
                    // guarantee that the mesh also does not change by more than refinement level across vertices that might connect two cells:
                    Triangulation<dim>::limit_level_difference_at_vertices),
-    dof_handler    (triangulation),
     mpi_communicator(MPI_COMM_WORLD)
   {}
 
@@ -42,7 +41,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (*config.get_stream(),
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     std::shared_ptr<Cluster::WeightsByBase<dim> > cluster_weights_method =
@@ -79,7 +78,6 @@ public:
 private:
   const ConfigureQC &config;
   parallel::shared::Triangulation<dim> triangulation;
-  DoFHandler<dim>      dof_handler;
   MPI_Comm mpi_communicator;
   CellMoleculeData<dim> cell_molecule_data;
 

--- a/tests/atom/cell_molecule_tools_thrown_molecules_02.cc
+++ b/tests/atom/cell_molecule_tools_thrown_molecules_02.cc
@@ -29,7 +29,6 @@ public:
     triangulation (MPI_COMM_WORLD,
                    // guarantee that the mesh also does not change by more than refinement level across vertices that might connect two cells:
                    Triangulation<dim>::limit_level_difference_at_vertices),
-    dof_handler    (triangulation),
     mpi_communicator(MPI_COMM_WORLD)
   {}
 
@@ -44,7 +43,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (fin,
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     std::shared_ptr<Cluster::WeightsByBase<dim> > cluster_weights_method =
@@ -76,7 +75,6 @@ public:
 private:
   const ConfigureQC &config;
   parallel::shared::Triangulation<dim> triangulation;
-  DoFHandler<dim>      dof_handler;
   MPI_Comm mpi_communicator;
   CellMoleculeData<dim> cell_molecule_data;
 

--- a/tests/atom/molecule_handler_neigh_list_01.cc
+++ b/tests/atom/molecule_handler_neigh_list_01.cc
@@ -28,8 +28,7 @@ public:
     config(config),
     triangulation (MPI_COMM_WORLD,
                    // guarantee that the mesh also does not change by more than refinement level across vertices that might connect two cells:
-                   Triangulation<dim>::limit_level_difference_at_vertices),
-    dof_handler    (triangulation)
+                   Triangulation<dim>::limit_level_difference_at_vertices)
   {}
 
   void run()
@@ -40,7 +39,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (*config.get_stream(),
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     std::shared_ptr<Cluster::WeightsByBase<dim> > cluster_weights_method =
@@ -68,7 +67,6 @@ public:
 private:
   const ConfigureQC &config;
   parallel::shared::Triangulation<dim> triangulation;
-  DoFHandler<dim>      dof_handler;
   CellMoleculeData<dim> cell_molecule_data;
 
 };

--- a/tests/atom/sampling/lumped_cluster_weights_03.cc
+++ b/tests/atom/sampling/lumped_cluster_weights_03.cc
@@ -38,7 +38,6 @@ public:
     triangulation (MPI_COMM_WORLD,
                    // guarantee that the mesh also does not change by more than refinement level across vertices that might connect two cells:
                    Triangulation<dim>::limit_level_difference_at_vertices),
-    dof_handler    (triangulation),
     mpi_communicator(MPI_COMM_WORLD)
   {}
 
@@ -66,7 +65,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (*config.get_stream(),
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     Cluster::WeightsByLumpedVertex<dim>
@@ -98,7 +97,6 @@ public:
 private:
   const ConfigureQC &config;
   parallel::shared::Triangulation<dim> triangulation;
-  DoFHandler<dim>      dof_handler;
   MPI_Comm mpi_communicator;
   CellMoleculeData<dim> cell_molecule_data;
 };

--- a/tests/atom/write_atom_data_into_vtp_01.cc
+++ b/tests/atom/write_atom_data_into_vtp_01.cc
@@ -53,7 +53,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (fin,
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     std::shared_ptr<Cluster::WeightsByBase<dim>> cluster_weights_method =

--- a/tests/atom/write_atom_data_into_vtp_02.cc
+++ b/tests/atom/write_atom_data_into_vtp_02.cc
@@ -52,7 +52,7 @@ public:
     cell_molecule_data =
       CellMoleculeTools::
       build_cell_molecule_data<dim> (*config.get_stream(),
-                                     dof_handler,
+                                     triangulation,
                                      config.get_ghost_cell_layer_thickness());
 
     for (auto &cell_molecule : cell_molecule_data.cell_molecules)

--- a/tests/core/energy_and_gradient_lj_02.cc
+++ b/tests/core/energy_and_gradient_lj_02.cc
@@ -58,7 +58,7 @@ Problem<dim, PotentialType>::Problem (const std::string &s)
     CellMoleculeTools::
     build_cell_molecule_data<dim>
     (*config.get_stream(),
-     QC<dim, PotentialType>::dof_handler,
+     QC<dim, PotentialType>::triangulation,
      config.get_ghost_cell_layer_thickness());
 }
 

--- a/tests/core/energy_and_gradient_lj_03.cc
+++ b/tests/core/energy_and_gradient_lj_03.cc
@@ -58,7 +58,7 @@ Problem<dim, PotentialType>::Problem (const std::string &s)
     CellMoleculeTools::
     build_cell_molecule_data<dim>
     (*config.get_stream(),
-     QC<dim, PotentialType>::dof_handler,
+     QC<dim, PotentialType>::triangulation,
      config.get_ghost_cell_layer_thickness());
 }
 

--- a/tests/core/energy_and_gradient_lj_04.cc
+++ b/tests/core/energy_and_gradient_lj_04.cc
@@ -58,7 +58,7 @@ Problem<dim, PotentialType>::Problem (const std::string &s)
     CellMoleculeTools::
     build_cell_molecule_data<dim>
     (*config.get_stream(),
-     QC<dim, PotentialType>::dof_handler,
+     QC<dim, PotentialType>::triangulation,
      config.get_ghost_cell_layer_thickness());
 }
 


### PR DESCRIPTION
+ some doc correction
+ now tests relating to building of cell molecules don't need `DoFHandler` object at all.