### PR TITLE
extend find_closest_point test

### DIFF
--- a/tests/utilities/find_closest_point_02.cc
+++ b/tests/utilities/find_closest_point_02.cc
@@ -36,6 +36,13 @@ void test()
     dealiiqc::Utilities::find_closest_point (p,
                                              points_1);
 
+  const auto closest_vertex =
+    dealiiqc::Utilities::find_closest_vertex (p,
+                                              tria.begin_active());
+
+  AssertThrow (closest.second == closest_vertex.second,
+               ExcInternalError());
+
   std::cout << closest.first  << " " << closest.second << std::endl;
 }
 


### PR DESCRIPTION
A quick extension of `find_closest_point_02` test to also check correctness of `find_closest_vertex()`.