### PR TITLE
1d function to determine indentor position is time

### DIFF
--- a/include/deal.II-qc/potentials/nano_indentor.h
+++ b/include/deal.II-qc/potentials/nano_indentor.h
@@ -44,7 +44,7 @@ public:
   void initialize (const std::string                   &variables,
                    const std::string                   &expression,
                    const std::map<std::string, double> &constants,
-                   const bool                           time_dependent = true);
+                   const bool                           time_dependent = false);
 
   /**
    * Move the indenter at the position corresponding to the time @p new_time.
@@ -57,7 +57,7 @@ protected:
    * FunctionParser object to describe the position of the indentor along
    * the direction of indentation #direction.
    */
-  FunctionParser<dim>  indentor_position_function;
+  FunctionParser<1>  indentor_position_function;
 
   /**
    * Initial location of the indentor.

--- a/source/potentials/nano_indentor.cc
+++ b/source/potentials/nano_indentor.cc
@@ -61,7 +61,7 @@ void NanoIndentor<dim>::set_time (const double new_time)
   FunctionTime<double>::set_time(new_time);
   indentor_position_function.set_time (new_time);
   current_location = initial_location +
-                     indentor_position_function.value(initial_location)
+                     indentor_position_function.value(new_time)
                      *
                      direction;
 }


### PR DESCRIPTION
Currently this one-d function is taking in `initial_location` to determine the indentor's location along a given direction. I think I just need time to locate it without more complications.