### PR TITLE
Zoltan produces stray output; suppress by using metis for now

### DIFF
--- a/include/deal.II-qc/grid/shared_tria.h
+++ b/include/deal.II-qc/grid/shared_tria.h
@@ -31,6 +31,8 @@ namespace parallel
     {
     public:
 
+      typedef typename dealii::parallel::shared::Triangulation<dim, spacedim>::Settings Settings;
+
       /**
        * Constructor.
        *
@@ -45,7 +47,8 @@ namespace parallel
       Triangulation (MPI_Comm mpi_communicator,
                      const typename dealii::Triangulation<dim,spacedim>::MeshSmoothing =
                        (dealii::Triangulation<dim,spacedim>::none),
-                     const double ghost_cell_layer_thickness = -1.);
+                     const double ghost_cell_layer_thickness = -1.,
+                     const Settings settings = Settings::partition_metis);
 
       // TODO: Need to rework for large deformations?
       /**

--- a/source/grid/shared_tria.cc
+++ b/source/grid/shared_tria.cc
@@ -17,11 +17,13 @@ namespace parallel
     template <int dim, int spacedim>
     Triangulation<dim,spacedim>::Triangulation (MPI_Comm mpi_communicator,
                                                 const typename dealii::Triangulation<dim,spacedim>::MeshSmoothing smooth_grid,
-                                                const double ghost_cell_layer_thickness)
+                                                const double ghost_cell_layer_thickness,
+                                                const Settings settings)
       :
       dealii::parallel::shared::Triangulation<dim,spacedim> (mpi_communicator,
                                                              smooth_grid,
-                                                             ghost_cell_layer_thickness >= 0.),
+                                                             ghost_cell_layer_thickness >= 0.,
+                                                             settings),
       ghost_cell_layer_thickness(ghost_cell_layer_thickness)
     {}
 


### PR DESCRIPTION
Zoltan is producing the following output, making tests fail.
```
ZOLTAN Load balancing method = 9 (GRAPH)
ZOLTAN Load balancing method = 9 (GRAPH)
```

Perhaps, we could use metis for the time being.