### PR TITLE
Revert "Zoltan produces stray output; suppress by using metis for now"

### DIFF
--- a/include/deal.II-qc/grid/shared_tria.h
+++ b/include/deal.II-qc/grid/shared_tria.h
@@ -31,8 +31,6 @@ namespace parallel
     {
     public:
 
-      typedef typename dealii::parallel::shared::Triangulation<dim, spacedim>::Settings Settings;
-
       /**
        * Constructor.
        *
@@ -47,8 +45,7 @@ namespace parallel
       Triangulation (MPI_Comm mpi_communicator,
                      const typename dealii::Triangulation<dim,spacedim>::MeshSmoothing =
                        (dealii::Triangulation<dim,spacedim>::none),
-                     const double ghost_cell_layer_thickness = -1.,
-                     const Settings settings = Settings::partition_metis);
+                     const double ghost_cell_layer_thickness = -1.);
 
       // TODO: Need to rework for large deformations?
       /**

--- a/source/grid/shared_tria.cc
+++ b/source/grid/shared_tria.cc
@@ -17,13 +17,11 @@ namespace parallel
     template <int dim, int spacedim>
     Triangulation<dim,spacedim>::Triangulation (MPI_Comm mpi_communicator,
                                                 const typename dealii::Triangulation<dim,spacedim>::MeshSmoothing smooth_grid,
-                                                const double ghost_cell_layer_thickness,
-                                                const Settings settings)
+                                                const double ghost_cell_layer_thickness)
       :
       dealii::parallel::shared::Triangulation<dim,spacedim> (mpi_communicator,
                                                              smooth_grid,
-                                                             ghost_cell_layer_thickness >= 0.,
-                                                             settings),
+                                                             ghost_cell_layer_thickness >= 0.),
       ghost_cell_layer_thickness(ghost_cell_layer_thickness)
     {}
 


### PR DESCRIPTION
Reverts davydden/deal.ii-qc#262

Since Zoltan is now fixed in dealii, I think we can revert it. 