### PR TITLE
add some more parameters to WeightsByBase

### DIFF
--- a/include/deal.II-qc/atom/sampling/weights_by_optimal_summation_rules.h
+++ b/include/deal.II-qc/atom/sampling/weights_by_optimal_summation_rules.h
@@ -15,34 +15,35 @@ namespace Cluster
 
   // TODO: Implementation (first order summation rule for now).
   /**
-   * The summation rules can be identified by two numbers: \f$ n_s\f$ the number
-   * of shells included in clusters around the cluster-type sampling atom, and
-   * \f$n_q\f$, the number of quadrature-type sampling atoms per element
-   * (clusters around these sampling atoms are not considered).
+   * Summation rules can be identified by two numbers: \f$ n_s\f$ the number
+   * of shells included in clusters around the (vertex-type) sampling
+   * atom/molecule, and \f$n_q\f$, the number of sampling atoms/molecules
+   * (per element) that are either inside or on the face or edges of the element
+   * (clusters around these sampling atoms/molecules are not considered).
    * Hence, a summation rule is characterized by the pair
    * (\f$n_s\f$, \f$n_q\f$). For example in two-dimensions (0,1) summation rule
    * (which is classified as to a first-order optimal summation rule)
-   * indicates that a quadrature-type sampling atom (if exists) at the center
+   * indicates that a sampling atom/molecule (if exists) at the center
    * of the element will also contribute towards energy and force computations.
-   * Such a sampling atom is also termed as inner-element sampling atom.
-   * The inner-element sampling atom represents all inner-element lattice sites
-   * except those within the representative distance (\f$r_{rep}\f$) of
-   * cluster-type sampling atoms.
+   * Such a sampling atom/molecule is also termed as inner-element sampling
+   * atom/molecule. The inner-element sampling atom/molecule represents
+   * all inner-element lattice sites except those within the representative
+   * distance (\f$r_{rep}\f$) of vertex-type sampling atoms/molecules.
    *
    * Nomenclature of summation rules:
    * - (0,0): a purely nodal summation rule,
    * - (\f$n_s\f$, 0): nodal cluster summation rules with \f$n_s\f$ shells of
-   * cluster atoms,
+   * cluster atoms/molecules,
    * - (0, \f$n_q\f$): quadrature summation rules with \f$n_q\f$ quadrature-type
    * sampling atoms per element,
    * - (0, 1): a first-order optimal summation rule with an inner-element
    * sampling atom.
    * - (0, 1, 4): a second-order optimal summation rule with an inner-element
-   * sampling atom along with four face center sampling atoms in the case of
-   * quadrilateral element ((0, 1, 6) for hexagonal elements).
+   * sampling atom/molecule along with four face center sampling atoms/molecules
+   * in the case of quadrilateral element ((0, 1, 6) for hexagonal elements).
    *
    * The representative distance (\f$r_{rep}\f$)(required to determine the
-   * weights of sampling atoms) is to be obtained through numerical
+   * weights of sampling atoms/molecules) is to be obtained through numerical
    * experimentation. It is therefore possible that the representative distance
    * is not a unique constant for a chosen interaction potential for
    * a material for any arbitrary simulation scenarios.
@@ -60,18 +61,54 @@ namespace Cluster
      * Constructor.
      */
     WeightsByOptimalSummationRules (const double &cluster_radius,
-                                    const double &maximum_energy_radius);
+                                    const double &maximum_energy_radius,
+                                    const double &rep_distance,
+                                    const double &molecule_density=std::numeric_limits<double>::signaling_NaN());
 
-    // TODO: More documentation.
+    // TODO: More documentation & implementation.
     /**
      * @see WeightsByBase::update_cluster_weights().
      *
-     * The approach of WeightsByOptimalSummationRules ...
+     * The approach of WeightsByOptimalSummationRules requires that a variable
+     * called representative distance is set based on numerical experimentation.
+     *
+     * Three specific cases exist:
+     * - In the fully atomistic region, cells do not contain sampling
+     *   atoms/molecules other than that of vertex-type.
+     *   In such a case, all the (vertex-type)
+     *   sampling points of the cell are given sampling weight of 1.
+     * - In the interface region (which typically come with hanging nodes),
+     *   the representative spheres of (vertex-type) sampling atoms/molecules
+     *   could potentially overlap. The representative spheres should be split to
+     *   determine sampling weights.
+     * - In the continuum region, cells are large enough that none of the
+     *   representative spheres overlap, the vertex-type sampling
+     *   atoms/molecules get a sampling weight of
+     *   \f$ 4/3 \pi r_r^3 \rho\f$ (for three-dimensions)
+     *   or \f$ \pi r_r^2 \rho\f$ (for two-dimensions),
+     *   where \f$ \rho\f$ is the atom/molecule number density of
+     *   the atomistic system and \f$r_r\f$ is the representative distance of
+     *   the vertex-type sampling atoms/molecules.
+     *
+     * For the first order summation rules, the sampling weight of
+     * the inner-element sampling atom/molecule (if exists), is given as
+     * \f$ w_q = \rho \nu - \sum_i{w_i}\f$
+     * where \f$ \rho\f$ is the atom/molecule number density of the atomistic
+     * system, \f$ w_i\f$ is the sampling weight of the vertex-type
+     * sampling atom \f$i\f$ of the cell and \f$ \nu\f$ is the volume of the
+     * cell containing the quadrature-type sampling atom.
      */
     types::CellMoleculeContainerType<dim, atomicity, spacedim>
     update_cluster_weights
     (const Triangulation<dim, spacedim>                               &triangulation,
      const types::CellMoleculeContainerType<dim, atomicity, spacedim> &cell_molecules) const;
+
+  private:
+
+    /**
+     * Representative distance of the vertex-type sampling atoms/molecules.
+     */
+    const double rep_distance;
 
   };
 

--- a/include/deal.II-qc/configure/configure_qc.h
+++ b/include/deal.II-qc/configure/configure_qc.h
@@ -16,6 +16,7 @@
 #include <deal.II-qc/atom/sampling/cluster_weights_by_cell.h>
 #include <deal.II-qc/atom/sampling/cluster_weights_by_lumped_vertex.h>
 #include <deal.II-qc/atom/sampling/cluster_weights_by_sampling_points.h>
+#include <deal.II-qc/atom/sampling/weights_by_optimal_summation_rules.h>
 #include <deal.II-qc/configure/geometry/geometry_box.h>
 #include <deal.II-qc/configure/geometry/geometry_gmsh.h>
 #include <deal.II-qc/potentials/pair_coul_wolf.h>
@@ -384,6 +385,11 @@ protected:
    * The cluster radius used in QC.
    */
   double cluster_radius;
+
+  /**
+   * Representative distance of (vertex-type) sampling points.
+   */
+  double rep_distance;
 
   /**
    * The type of method to update cluster weights.

--- a/source/configure/configure_qc.cc
+++ b/source/configure/configure_qc.cc
@@ -111,6 +111,11 @@ ConfigureQC::get_cluster_weights() const
       std::make_shared<Cluster::WeightsBySamplingPoints<dim, atomicity, spacedim>>
       (cluster_radius, maximum_cutoff_radius);
 
+  else if (cluster_weights_type == "OptimalSummationRules")
+    return
+      std::make_shared<Cluster::WeightsByOptimalSummationRules<dim, atomicity, spacedim>>
+      (cluster_radius, maximum_cutoff_radius, rep_distance);
+
   else
     AssertThrow (false, ExcInternalError());
 
@@ -294,10 +299,16 @@ void ConfigureQC::declare_parameters (ParameterHandler &prm)
                       "Cluster radius used in "
                       "QC simulation");
     prm.declare_entry("Cluster weights by type", "Cell",
-                      Patterns::Selection("Cell|LumpedVertex|SamplingPoints"),
+                      Patterns::Selection("Cell|LumpedVertex|SamplingPoints|"
+                                          "OptimalSummationRules"),
                       "Select the way how cluster "
                       "weights are computed for "
                       "cluster atoms.");
+    prm.declare_entry("Representative distance", "1.0",
+                      Patterns::Double(0),
+                      "Representative distance of vertex-type "
+                      "sampling points used only in the case when "
+                      "the weights are set by OptimalSummationRules.");
   }
   prm.leave_subsection ();
 
@@ -574,6 +585,7 @@ void ConfigureQC::parse_parameters (ParameterHandler &prm)
 
     cluster_radius = prm.get_double( "Cluster radius");
     cluster_weights_type = prm.get("Cluster weights by type");
+    rep_distance = prm.get("Representative distance");
   }
   prm.leave_subsection();
 


### PR DESCRIPTION
Two more arguments added to `WeightsByBase`constructor to be used in `WeightsByOptimalSummationRules`.

Actually `molecule_density` can be figured out by summing up the number of molecules and adding up the cell measure for locally owned processes. Should I keep the argument or skip it?