### PR TITLE
suppressing signed and unsigned int comparision; indentation

### DIFF
--- a/include/deal.II-qc/base/quadrature_lib.h
+++ b/include/deal.II-qc/base/quadrature_lib.h
@@ -16,11 +16,11 @@ DEAL_II_QC_NAMESPACE_OPEN
 template <int dim>
 class QTrapezWithMidpoint : public dealii::Quadrature<dim>
 {
-  public:
-    /**
-     * Constructor.
-     */
-    QTrapezWithMidpoint();
+public:
+  /**
+   * Constructor.
+   */
+  QTrapezWithMidpoint();
 };
 
 

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -1,8 +1,8 @@
 
-#include <deal.II/base/utilities.h>
-#include <deal.II-qc/base/quadrature_lib.h>
-
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/geometry_info.h>
+
+#include <deal.II-qc/base/quadrature_lib.h>
 
 
 DEAL_II_QC_NAMESPACE_OPEN
@@ -12,10 +12,10 @@ using namespace dealii;
 
 template <int dim>
 QTrapezWithMidpoint<dim>::QTrapezWithMidpoint()
-:
-Quadrature<dim>(dealii::Utilities::fixed_power<dim, int>(2)+1)
+  :
+  Quadrature<dim>(GeometryInfo<dim>::vertices_per_cell +1)
 {
-  const int n_points  = dealii::Utilities::fixed_power<dim, int>(2)+1;
+  const unsigned int n_points = GeometryInfo<dim>::vertices_per_cell +1;
   const double weight = 1./static_cast<double>(n_points);
 
   QTrapez<dim> q_trapez;
@@ -23,7 +23,7 @@ Quadrature<dim>(dealii::Utilities::fixed_power<dim, int>(2)+1)
   this->quadrature_points = q_trapez.get_points();
 
   for (unsigned int i=0; i<q_midpoint.size(); ++i)
-   this->quadrature_points.push_back(q_midpoint.point(i));
+    this->quadrature_points.push_back(q_midpoint.point(i));
 
   Assert (this->quadrature_points.size()==n_points,
           ExcInternalError());


### PR DESCRIPTION
`GeometryInfo<dim>::vertices_per_cell` is computed much efficiently as it was done here.