### PR TITLE
level of cell is of type int; suppress warnings with gcc@5.4.0

### DIFF
--- a/source/atom/sampling/weights_by_optimal_summation_rules.cc
+++ b/source/atom/sampling/weights_by_optimal_summation_rules.cc
@@ -59,7 +59,7 @@ namespace Cluster
                                hyperball_segment_volume<dim>(rep_distance,
                                                              0);
 
-    const unsigned int n_levels = triangulation.n_global_levels();
+    const int n_levels = triangulation.n_global_levels();
     std::vector<bool>  weight_assigned (n_sampling_points, false);
 
     // Initialize with a full weights for all the sampling points.


### PR DESCRIPTION
Cell level is of int type. Realized this when I was trying to build code with gcc@5.4.0 (it threw warnings).